### PR TITLE
fix(auth): use configurable API host + allow www origin

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -163,6 +163,7 @@ const allowedOrigins = [
     'https://hashnhedge-app.up.railway.app',
     'https://app.hashnhedge.com',
     'https://hashnhedge.com',
+    'https://www.hashnhedge.com',
     'https://app-production-374e.up.railway.app',
     'https://app-production-564e.up.railway.app',
     'http://localhost:3000',

--- a/hooks/useAgentStatus.ts
+++ b/hooks/useAgentStatus.ts
@@ -26,7 +26,7 @@ export const useAgentStatus = (user: User | null) => {
             }
 
             // Wallet check
-            const apiBase = import.meta.env.VITE_API_URL || 'https://api.hashnhedge.com';
+            const apiBase = localStorage.getItem('hnh_api_url') || import.meta.env.VITE_API_URL || 'https://api-production-5f42.up.railway.app';
             const token = localStorage.getItem('hnh_token');
             if (token) {
                 try {

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -5,7 +5,7 @@
  * for all backend service calls.
  */
 
-export const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://api-production-5f42.up.railway.app';
+export const API_BASE_URL = localStorage.getItem('hnh_api_url') || import.meta.env.VITE_API_URL || 'https://api-production-5f42.up.railway.app';
 
 interface RequestOptions extends RequestInit {
   params?: Record<string, string | number>;

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -4,7 +4,7 @@ import { apiClient } from './apiClient';
 // Cache for user data
 let cachedUser: User | null = null;
 
-export const API_URL = import.meta.env.VITE_API_URL || 'https://api-production-5f42.up.railway.app';
+export const API_URL = localStorage.getItem('hnh_api_url') || import.meta.env.VITE_API_URL || 'https://api-production-5f42.up.railway.app';
 
 export const setCachedUser = (user: User | null) => {
     cachedUser = user;


### PR DESCRIPTION
This PR deploys the auth hotfix safely without force-pushing main.

Changes:
- Backend CORS: allow https://www.hashnhedge.com
- Frontend API resolution: localStorage hnh_api_url override -> VITE_API_URL -> Railway fallback
- Agent status wallet checks now use the same API fallback chain

Why:
- Avoids dependency on broken api.hashnhedge.com redirect path for login/OAuth flows.
