### PR TITLE
fix(api): use postgresql prisma provider for Railway deploys

### DIFF
--- a/backend/api/schema.prisma
+++ b/backend/api/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {


### PR DESCRIPTION
Railway api builds were failing at prisma generate because schema used sqlite while models include Json fields unsupported by sqlite connector.

This switches backend/api/schema.prisma datasource to:
- provider = postgresql
- url = env(DATABASE_URL)

Expected result: api service builds/deploys successfully on Railway and picks up merged auth/CORS fixes.