### PR TITLE
fix(api): allow prisma db push on startup in production

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -26,5 +26,5 @@ COPY version.json* ./
 EXPOSE 8080
 
 # Sync the current PostgreSQL schema and start the server
-CMD npx prisma db push && node index.js
+CMD npx prisma db push --accept-data-loss && node index.js
 


### PR DESCRIPTION
Startup was crashing because prisma db push aborted on data-loss warnings.\n\nThis hotfix adds --accept-data-loss to startup db push so api can boot and serve traffic.\n\nFollow-up: replace runtime db push with explicit migrations and preflight checks.