### PR TITLE
Start production readiness foundation

### DIFF
--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -1,0 +1,151 @@
+# HashNHedge Production Readiness Project Board
+
+This file mirrors the intended GitHub Projects board so the roadmap remains version-controlled inside the repository.
+
+## Board columns
+
+1. **Backlog**
+2. **Ready**
+3. **In Progress**
+4. **Review / Audit**
+5. **Blocked**
+6. **Done**
+
+## Epic 1: Backend orchestration platform
+
+**Objective:** Replace prototype/backend sprawl with a scalable NestJS control plane and FastAPI worker adapters.
+
+| Task | Status | Notes |
+| --- | --- | --- |
+| ADR: NestJS vs FastAPI | Done | See `docs/adr/ADR-001-backend-framework.md` |
+| Create NestJS orchestrator skeleton | Ready | `services/orchestrator` |
+| Define service boundaries | Ready | Auth, workers, jobs, vendors, payments, monitoring |
+| Add worker registry module | Backlog | Worker enrollment, capabilities, heartbeat |
+| Add job scheduler module | Backlog | Leasing, retries, state machine |
+| Add payment coordinator module | Backlog | Off-chain coordination + on-chain settlement |
+| Add Solana coordinator module | Backlog | Anchor program integration |
+| Add integration tests | Backlog | API + job lifecycle |
+
+## Epic 2: Anchor smart contracts
+
+**Objective:** Build audited Anchor programs for trust-critical compute and settlement workflows.
+
+| Task | Status | Notes |
+| --- | --- | --- |
+| Anchor workspace skeleton | Ready | `contracts/anchor` |
+| Worker registry program | Backlog | Worker identity and staking hooks |
+| Task registry program | Backlog | Task records and proof tracking |
+| Escrow program | Backlog | Vendor deposits and payout reserves |
+| Rewards program | Backlog | Worker payouts and revenue share |
+| Governance and pause controls | Backlog | Multisig/admin safety |
+| Anchor tests | Backlog | Unit + localnet integration |
+| Internal audit checklist | Backlog | Before third-party audit |
+| Third-party audit | Backlog | Required before mainnet launch |
+
+## Epic 3: Security hardening
+
+**Objective:** Secure API, worker, infrastructure, and smart-contract layers before public launch.
+
+| Task | Status | Notes |
+| --- | --- | --- |
+| JWT/session auth | Ready | Access + refresh token strategy |
+| RBAC | Ready | Miner, vendor, community, admin, super admin |
+| MFA-ready admin access | Backlog | TOTP or passkey-ready |
+| Scoped API keys | Backlog | Vendor and worker API keys |
+| Request signing | Backlog | Nonce/timestamp replay protection |
+| Centralized validation | Backlog | DTO/schema validation |
+| Redacted structured logging | Backlog | No secrets/tokens in logs |
+| API circuit breakers | Backlog | Payouts, registration, job creation, admin |
+| Security review cadence | Backlog | Recurring assessment checklist |
+
+## Epic 4: Containerized GPU orchestration
+
+**Objective:** Run workloads in isolated GPU-aware containers and scale workers efficiently.
+
+| Task | Status | Notes |
+| --- | --- | --- |
+| Worker container baseline | Ready | Docker + NVIDIA Container Toolkit |
+| GPU telemetry sidecar | Backlog | Utilization, memory, model/job metrics |
+| AI inference worker | Backlog | Triton-ready |
+| Dynamo gateway worker | Backlog | Distributed inference optimization |
+| Scheduler-to-worker protocol | Backlog | Lease, ack, result, proof, heartbeat |
+| Autoscaling strategy | Backlog | Recover when workers disappear |
+| Observability dashboard | Backlog | Queue depth, GPU use, failure rate, payouts |
+
+## Epic 5: Marketplace and payments
+
+**Objective:** Create a trusted compute marketplace with vendor onboarding, pricing, SLAs, and settlement.
+
+| Task | Status | Notes |
+| --- | --- | --- |
+| Vendor onboarding flow | Backlog | KYB/KYC-ready later |
+| Compute job creation | Backlog | Vendor API + dashboard |
+| Pricing engine | Backlog | GPU type, urgency, runtime, marketplace demand |
+| Escrow settlement flow | Backlog | Off-chain workflow + Solana escrow |
+| SLA tracking | Backlog | Job runtime, success rate, uptime |
+| Revenue analytics | Backlog | Platform fee, worker earnings, liabilities |
+
+## Epic 6: Observability and operations
+
+**Objective:** Make the system measurable, debuggable, and operable.
+
+| Task | Status | Notes |
+| --- | --- | --- |
+| OpenTelemetry baseline | Backlog | API traces and job lifecycle traces |
+| Prometheus metrics | Backlog | API + worker + queue metrics |
+| Grafana dashboards | Backlog | SLO dashboards |
+| Loki logs | Backlog | Structured log aggregation |
+| Sentry | Backlog | Error reporting |
+| Solana event indexer | Backlog | Program events + suspicious state changes |
+| Alerting rules | Backlog | API errors, payout anomalies, worker churn |
+
+## Milestones
+
+### Milestone 1: Control plane foundation
+
+- NestJS skeleton
+- Auth module starter
+- Worker registry starter
+- Job state machine interfaces
+- Health checks
+
+### Milestone 2: Secure worker/job loop
+
+- Worker registration
+- Heartbeat
+- Job leasing
+- Retry and dead-letter handling
+- Integration tests
+
+### Milestone 3: Anchor MVP
+
+- Anchor workspace
+- Worker registry
+- Task registry
+- Escrow proof of concept
+- Localnet tests
+
+### Milestone 4: GPU runtime MVP
+
+- Containerized GPU worker
+- GPU telemetry
+- Triton adapter proof of concept
+- Scheduler-to-worker protocol
+
+### Milestone 5: Security and observability hardening
+
+- RBAC
+- API keys
+- Request signing
+- Structured logs
+- Dashboards and alerts
+- Circuit breakers
+
+### Milestone 6: Launch readiness
+
+- Internal audit
+- Third-party smart-contract audit
+- Load testing
+- Penetration testing
+- Runbooks
+- Mainnet/testnet launch decision

--- a/contracts/anchor/README.md
+++ b/contracts/anchor/README.md
@@ -1,0 +1,59 @@
+# HashNHedge Anchor Programs
+
+This directory is the target workspace for Solana/Anchor programs.
+
+## Programs to build
+
+1. **Worker Registry**
+   - worker identity
+   - operator wallet
+   - capability metadata hash
+   - reputation hooks
+   - optional stake hooks
+
+2. **Task Registry**
+   - task records
+   - requester identity
+   - task metadata hash
+   - proof/result hash
+   - lifecycle state mirror
+
+3. **Escrow**
+   - vendor deposits
+   - reserved job budget
+   - payout release
+   - refund path
+
+4. **Rewards**
+   - worker reward calculation
+   - platform fee calculation
+   - payout accounting
+
+5. **Governance / Emergency Controls**
+   - multisig admin authority
+   - pause controls
+   - parameter updates
+   - emergency withdrawal policy
+
+## Security requirements
+
+Every program must include:
+
+- signer validation
+- owner validation
+- PDA derivation checks
+- checked arithmetic
+- strict account sizing
+- event emission
+- pause controls for high-risk flows
+- test coverage for failure cases
+
+## Launch rule
+
+No mainnet deployment until:
+
+- localnet tests pass
+- devnet/testnet deployment has been exercised
+- internal audit checklist is complete
+- third-party audit is complete
+- emergency procedures are documented

--- a/docs/adr/ADR-001-backend-framework.md
+++ b/docs/adr/ADR-001-backend-framework.md
@@ -1,0 +1,128 @@
+# ADR-001: Backend framework for HashNHedge orchestration
+
+## Status
+
+Accepted
+
+## Context
+
+HashNHedge needs a production-grade off-chain orchestration layer for worker registration, compute job scheduling, vendor marketplace workflows, pool statistics, payment coordination, monitoring, and admin controls.
+
+The current backend is primarily Express/Node. That is workable for a prototype, but HashNHedge is moving toward a multi-service platform with:
+
+- decentralized GPU worker coordination
+- vendor-facing compute marketplace APIs
+- miner/worker telemetry
+- payout and escrow coordination
+- Solana program integration
+- security-sensitive admin operations
+- high-volume job scheduling and state transitions
+
+The framework choice should optimize for maintainability, resilience, security boundaries, and team scaling.
+
+## Options considered
+
+### Option A: NestJS
+
+**Strengths**
+
+- Strong module architecture for large Node/TypeScript systems
+- Dependency injection and clear service boundaries
+- First-class TypeScript support
+- Mature guard/interceptor/pipe system for auth, validation, logging, and rate limiting
+- Good fit for REST, WebSocket, queue workers, and microservices
+- Easier migration path from existing Node/Express code
+- Strong ecosystem for Prisma, Passport/JWT, OpenAPI, BullMQ, Redis, NATS, Kafka, and observability
+
+**Weaknesses**
+
+- More boilerplate than FastAPI
+- GPU/ML runtime integration is not as natural as Python
+- Requires discipline to avoid over-engineering
+
+### Option B: FastAPI
+
+**Strengths**
+
+- Excellent Python ergonomics
+- Native fit for ML/GPU-adjacent services
+- Great OpenAPI generation
+- Fast iteration speed
+- Strong validation via Pydantic
+- Natural integration with AI, Triton clients, CUDA-adjacent Python tooling, and scientific libraries
+
+**Weaknesses**
+
+- Less structured for very large multi-domain backends unless conventions are enforced
+- Migration from existing Node code is larger
+- Enterprise auth/RBAC patterns require more custom assembly
+- Less natural fit for the existing JavaScript-heavy repository
+
+## Decision
+
+Use **NestJS** as the primary HashNHedge control-plane backend.
+
+Use **FastAPI** selectively for GPU/AI worker-adjacent microservices.
+
+## Rationale
+
+HashNHedge's core orchestration layer is closer to an enterprise marketplace and job-control system than a model-serving service. It needs strong boundaries around authentication, authorization, job lifecycle management, payments, vendor workflows, and Solana coordination.
+
+NestJS is the better default for the control plane because it gives HashNHedge:
+
+- clear modules and service boundaries
+- a safe migration path from Express
+- production-ready guard/interceptor/validation patterns
+- strong TypeScript contracts for public APIs
+- easier team onboarding as the codebase grows
+
+FastAPI remains the better choice for GPU runtime adapters, AI inference workers, Triton/Dynamo gateways, and ML-specific services.
+
+## Target split
+
+```text
+NestJS control plane
+  ├── Auth module
+  ├── Worker registry module
+  ├── Job scheduler module
+  ├── Vendor marketplace module
+  ├── Payment coordination module
+  ├── Solana coordination module
+  ├── Monitoring module
+  └── Admin module
+
+FastAPI worker services
+  ├── Triton gateway
+  ├── Dynamo gateway
+  ├── GPU telemetry collector
+  ├── AI inference worker
+  └── Specialized compute adapters
+```
+
+## Consequences
+
+### Positive
+
+- Stronger long-term maintainability
+- Better security and validation consistency
+- Easier migration from existing Node backend
+- Clear path to modular services and event-driven orchestration
+
+### Negative
+
+- Requires TypeScript/NestJS setup work
+- ML/GPU service code will likely still need Python services
+- Requires an explicit service contract between NestJS and FastAPI workers
+
+## Implementation plan
+
+1. Create `services/orchestrator` as the NestJS control plane.
+2. Define DTOs and OpenAPI schemas for worker, job, vendor, auth, stats, and payment APIs.
+3. Add Prisma integration using the existing data model as a starting point.
+4. Implement worker heartbeat and job lifecycle state machine first.
+5. Add FastAPI worker templates under `services/workers` for GPU-specific workloads.
+6. Add integration tests before production deployment.
+
+## Review date
+
+Revisit after the first production-readiness milestone or after a complete worker/job/payout flow is implemented.

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -1,0 +1,205 @@
+# HashNHedge Target Production Architecture
+
+## Purpose
+
+This document defines the target architecture for the future HashNHedge platform:
+
+- GPU farms and independent workers contribute compute.
+- A NestJS control plane coordinates workers, vendors, jobs, payments, and Solana interactions.
+- FastAPI worker services handle GPU/AI-adjacent runtime tasks.
+- Anchor-based Solana programs manage trust-critical registries, escrow, proofs, rewards, governance, and emergency controls.
+- Observability and security controls wrap the full stack.
+
+## High-level architecture
+
+```mermaid
+flowchart TB
+  Website[HashNHedge website and dashboards]
+  Vendors[Vendors / compute buyers]
+  Miners[Miners / GPU operators]
+
+  Gateway[API Gateway]
+  Auth[Auth and RBAC]
+  Orchestrator[NestJS Orchestrator]
+  Scheduler[Job Scheduler]
+  Payments[Payment Coordinator]
+  Monitoring[Monitoring and Audit]
+  EventBus[Event Bus: NATS / Kafka / Redis Streams]
+
+  WorkerA[GPU Farm Node A]
+  WorkerB[GPU Farm Node B]
+  WorkerN[GPU Farm Node N]
+
+  Runtime[Worker Runtime Layer]
+  Docker[Docker + NVIDIA Container Toolkit]
+  Triton[NVIDIA Triton]
+  Dynamo[NVIDIA Dynamo]
+  FastAPI[FastAPI worker adapters]
+
+  Solana[Solana / Anchor Programs]
+  WorkerRegistry[Worker Registry Program]
+  TaskRegistry[Task Registry Program]
+  Escrow[Escrow Program]
+  Rewards[Rewards Program]
+  Governance[Governance and Pause Controls]
+
+  Observability[Prometheus / Grafana / Loki / Sentry / OpenTelemetry]
+
+  Website --> Gateway
+  Vendors --> Gateway
+  Miners --> Gateway
+
+  Gateway --> Auth
+  Gateway --> Orchestrator
+  Orchestrator --> Scheduler
+  Orchestrator --> Payments
+  Orchestrator --> Monitoring
+  Orchestrator --> EventBus
+
+  EventBus --> WorkerA
+  EventBus --> WorkerB
+  EventBus --> WorkerN
+
+  WorkerA --> Runtime
+  WorkerB --> Runtime
+  WorkerN --> Runtime
+
+  Runtime --> Docker
+  Runtime --> Triton
+  Runtime --> Dynamo
+  Runtime --> FastAPI
+
+  Orchestrator --> Solana
+  Payments --> Solana
+  Solana --> WorkerRegistry
+  Solana --> TaskRegistry
+  Solana --> Escrow
+  Solana --> Rewards
+  Solana --> Governance
+
+  Orchestrator --> Observability
+  Runtime --> Observability
+  Solana --> Observability
+```
+
+## Control plane responsibilities
+
+The NestJS orchestrator owns the off-chain coordination layer:
+
+- identity, authentication, API keys, and RBAC
+- worker registration and heartbeat tracking
+- job intake and validation
+- job scheduling and leasing
+- retry and dead-letter handling
+- vendor marketplace flows
+- payout coordination
+- Solana transaction preparation and indexing
+- admin controls and audit logging
+- API-level circuit breakers
+
+## Worker runtime responsibilities
+
+Worker runtimes should be containerized and replaceable. Each worker reports its capabilities and accepts leased jobs from the orchestrator.
+
+Initial worker types:
+
+- mining worker
+- AI inference worker
+- general compute worker
+- GPU telemetry sidecar
+- Triton gateway worker
+- Dynamo gateway worker
+
+## Job lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Assigned: scheduler leases job
+  Assigned --> Running: worker accepts lease
+  Running --> ProofSubmitted: worker submits result/proof
+  ProofSubmitted --> Verified: verifier accepts proof
+  ProofSubmitted --> Failed: verifier rejects proof
+  Verified --> Paid: payout or escrow release succeeds
+  Paid --> [*]
+  Failed --> RetryQueued: retry budget remains
+  RetryQueued --> Queued
+  Failed --> DeadLettered: retry budget exhausted
+  DeadLettered --> [*]
+  Assigned --> LeaseExpired: heartbeat missing
+  LeaseExpired --> Queued
+```
+
+## Solana program responsibilities
+
+Anchor programs should only own trust-critical state and settlement workflows:
+
+- worker registry
+- task registry
+- escrow accounts
+- proof submission records
+- reward distribution
+- admin/multisig governance
+- pause/emergency controls
+
+Off-chain systems should not rely on smart contracts for every scheduling action. High-frequency orchestration should remain off-chain, while settlement, proofs, escrow, and public accountability live on-chain.
+
+## Security boundaries
+
+### API boundary
+
+- JWT/session authentication
+- scoped API keys for vendors and workers
+- request signing for workers
+- nonce/timestamp replay protection
+- endpoint-specific rate limits
+- payload size limits
+- centralized validation and sanitization
+- audit logging and redaction
+
+### Worker boundary
+
+- jobs run in containers
+- GPU access limited to declared device scope
+- no untrusted workload gets host-level privileges
+- network egress rules by job type
+- signed worker releases
+- telemetry sidecar reports utilization and health
+
+### Solana boundary
+
+- PDA validation
+- signer checks
+- checked arithmetic
+- multisig admin controls
+- pause controls on payout and escrow flows
+- event monitoring
+- third-party audit before mainnet launch
+
+## Observability requirements
+
+Minimum production dashboards:
+
+- active workers
+- worker heartbeat freshness
+- GPU utilization
+- queued/running/failed jobs
+- proof verification success rate
+- payout liability
+- API error rate
+- API p95/p99 latency
+- Solana transaction failures
+- security events
+
+## Initial build sequence
+
+1. NestJS orchestrator skeleton
+2. Worker heartbeat and registry
+3. Job lifecycle state machine
+4. Worker lease and retry logic
+5. Containerized worker template
+6. GPU telemetry
+7. Anchor program skeleton
+8. Escrow/reward proof of concept
+9. Observability baseline
+10. Security hardening pass

--- a/services/orchestrator/README.md
+++ b/services/orchestrator/README.md
@@ -1,0 +1,51 @@
+# HashNHedge Orchestrator Service
+
+This directory is the target home for the NestJS control-plane backend.
+
+## Responsibility
+
+The orchestrator coordinates off-chain workflows:
+
+- authentication and RBAC
+- worker registration and heartbeats
+- job scheduling and leasing
+- vendor marketplace APIs
+- payment coordination
+- Solana transaction coordination
+- observability and audit logging
+- circuit breakers for high-risk actions
+
+## Initial module layout
+
+```text
+services/orchestrator/
+├── src/
+│   ├── auth/
+│   ├── workers/
+│   ├── jobs/
+│   ├── vendors/
+│   ├── payments/
+│   ├── solana/
+│   ├── monitoring/
+│   ├── admin/
+│   └── common/
+├── prisma/
+├── test/
+└── README.md
+```
+
+## First build target
+
+Milestone 1 should produce:
+
+- NestJS application skeleton
+- health endpoint
+- config validation
+- auth module starter
+- worker registry module starter
+- job lifecycle types
+- integration test harness
+
+## Framework decision
+
+See `docs/adr/ADR-001-backend-framework.md`.

--- a/services/orchestrator/src/jobs/job-lifecycle.md
+++ b/services/orchestrator/src/jobs/job-lifecycle.md
@@ -1,0 +1,68 @@
+# Job Lifecycle State Machine
+
+HashNHedge jobs must move through explicit states so workers, vendors, payments, and Solana settlement remain consistent.
+
+## States
+
+| State | Meaning |
+| --- | --- |
+| `queued` | Job accepted and waiting for assignment |
+| `assigned` | Scheduler leased the job to a worker |
+| `running` | Worker accepted the lease and started work |
+| `proof_submitted` | Worker submitted result/proof metadata |
+| `verified` | Proof/result passed verification |
+| `paid` | Reward or escrow settlement completed |
+| `failed` | Job failed and may retry |
+| `retry_queued` | Job returned to queue after retryable failure |
+| `dead_lettered` | Retry budget exhausted or manual review required |
+| `lease_expired` | Worker missed heartbeat or did not accept in time |
+
+## Required metadata
+
+Each job should track:
+
+- `jobId`
+- `vendorId` or requester identity
+- `jobType`
+- `requirements`
+- `reward` / budget
+- `assignedWorkerId`
+- `leaseId`
+- `leaseExpiresAt`
+- `retryCount`
+- `maxRetries`
+- `proofHash`
+- `resultUri`
+- `verificationStatus`
+- `payoutStatus`
+- `createdAt`, `updatedAt`, `completedAt`
+
+## Transitions
+
+```mermaid
+stateDiagram-v2
+  [*] --> queued
+  queued --> assigned
+  assigned --> running
+  running --> proof_submitted
+  proof_submitted --> verified
+  verified --> paid
+  paid --> [*]
+  proof_submitted --> failed
+  running --> failed
+  assigned --> lease_expired
+  lease_expired --> queued
+  failed --> retry_queued
+  retry_queued --> queued
+  failed --> dead_lettered
+  dead_lettered --> [*]
+```
+
+## Guardrails
+
+- A worker can only claim a job with an active lease.
+- A lease must expire automatically if the worker heartbeat is stale.
+- A job cannot be paid unless it is verified.
+- A job cannot be verified unless proof/result metadata exists.
+- A worker cannot submit proof for a job assigned to another worker.
+- Every state transition must emit an audit event.

--- a/services/workers/README.md
+++ b/services/workers/README.md
@@ -1,0 +1,53 @@
+# HashNHedge Worker Runtime Services
+
+This directory is the target home for containerized GPU and compute workers.
+
+## Worker types
+
+- `miner-worker`: mining jobs and share submission
+- `inference-worker`: AI inference workloads
+- `triton-gateway`: NVIDIA Triton integration
+- `dynamo-gateway`: NVIDIA Dynamo integration
+- `telemetry-sidecar`: GPU utilization and health reporting
+- `general-compute-worker`: controlled generic compute jobs
+
+## Runtime baseline
+
+Workers should run inside containers with:
+
+- Docker
+- NVIDIA Container Toolkit
+- explicit GPU device assignment
+- restricted filesystem access
+- restricted network egress by job type
+- signed releases
+- heartbeat reporting
+- structured logs
+- job lease acknowledgement
+
+## Scheduler protocol
+
+Each worker should support:
+
+1. register capabilities
+2. send heartbeat
+3. receive job lease
+4. acknowledge job lease
+5. stream progress
+6. submit result/proof metadata
+7. report failure
+8. shut down gracefully
+
+## Telemetry
+
+Minimum metrics:
+
+- GPU model
+- GPU memory total/used
+- GPU utilization
+- temperature
+- power draw
+- active job ID
+- runtime seconds
+- error count
+- result/proof hash


### PR DESCRIPTION
## Summary

Starts the HashNHedge production-readiness buildout with foundational architecture docs and scaffolds.

## Added

- `PROJECT_BOARD.md` — version-controlled project board with epics, tasks, statuses, and milestones
- `docs/adr/ADR-001-backend-framework.md` — NestJS vs FastAPI decision record
- `docs/architecture/target-architecture.md` — target architecture with Mermaid diagrams
- `services/orchestrator/README.md` — NestJS control-plane scaffold
- `services/orchestrator/src/jobs/job-lifecycle.md` — job lifecycle state machine
- `contracts/anchor/README.md` — Anchor smart contract workspace plan
- `services/workers/README.md` — GPU worker runtime scaffold

## Notes

This PR is intentionally documentation/scaffold-first. It sets the system boundaries before implementation begins so the next commits can add the NestJS orchestrator, worker registry, heartbeat flow, and job scheduler without guessing at architecture.

Closes #31 once the roadmap is expanded into implementation issues and the initial scaffolding is merged.