### PR TITLE
Build NestJS orchestrator foundation

### DIFF
--- a/services/orchestrator/.env.example
+++ b/services/orchestrator/.env.example
@@ -1,0 +1,6 @@
+NODE_ENV=development
+ORCHESTRATOR_PORT=4100
+ORCHESTRATOR_VERSION=0.1.0
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
+JWT_SECRET=replace-with-a-strong-secret
+DATABASE_URL=postgresql://user:password@localhost:5432/hashnhedge

--- a/services/orchestrator/.eslintrc.json
+++ b/services/orchestrator/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["plugin:@typescript-eslint/recommended"],
+  "root": true,
+  "env": {
+    "node": true,
+    "jest": true
+  },
+  "ignorePatterns": ["dist", "coverage"]
+}

--- a/services/orchestrator/README.md
+++ b/services/orchestrator/README.md
@@ -1,10 +1,8 @@
 # HashNHedge Orchestrator Service
 
-This directory is the target home for the NestJS control-plane backend.
+NestJS control-plane backend for HashNHedge production orchestration.
 
-## Responsibility
-
-The orchestrator coordinates off-chain workflows:
+## Responsibilities
 
 - authentication and RBAC
 - worker registration and heartbeats
@@ -15,36 +13,43 @@ The orchestrator coordinates off-chain workflows:
 - observability and audit logging
 - circuit breakers for high-risk actions
 
-## Initial module layout
+## Local setup
 
-```text
-services/orchestrator/
-├── src/
-│   ├── auth/
-│   ├── workers/
-│   ├── jobs/
-│   ├── vendors/
-│   ├── payments/
-│   ├── solana/
-│   ├── monitoring/
-│   ├── admin/
-│   └── common/
-├── prisma/
-├── test/
-└── README.md
+```bash
+cd services/orchestrator
+cp .env.example .env
+npm install
+npm run start:dev
 ```
 
-## First build target
+The API listens on `ORCHESTRATOR_PORT`, defaulting to `4100`.
 
-Milestone 1 should produce:
+## Endpoints in this foundation PR
 
-- NestJS application skeleton
-- health endpoint
-- config validation
-- auth module starter
-- worker registry module starter
-- job lifecycle types
-- integration test harness
+- `GET /health`
+- `POST /workers`
+- `GET /workers`
+- `GET /workers/:workerId`
+- `POST /workers/:workerId/heartbeat`
+- `POST /jobs`
+- `GET /jobs`
+- `GET /jobs/:jobId`
+- `POST /jobs/lease-next`
+- `POST /jobs/:jobId/running`
+
+## API docs
+
+Swagger docs are exposed at `/docs` when the service is running.
+
+## Testing
+
+```bash
+npm test
+```
+
+## Notes
+
+This is a first implementation pass. The worker and job stores are intentionally in-memory so the API contract, validation, and lifecycle can be hardened before wiring in PostgreSQL/Prisma persistence.
 
 ## Framework decision
 

--- a/services/orchestrator/nest-cli.json
+++ b/services/orchestrator/nest-cli.json
@@ -1,0 +1,7 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@hashnhedge/orchestrator",
+  "version": "0.1.0",
+  "private": true,
+  "description": "HashNHedge production control-plane orchestrator",
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main.js",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --max-warnings=0",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.15",
+    "@nestjs/config": "^3.3.0",
+    "@nestjs/core": "^10.4.15",
+    "@nestjs/platform-express": "^10.4.15",
+    "@nestjs/swagger": "^8.1.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "helmet": "^8.0.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.8",
+    "@nestjs/schematics": "^10.2.3",
+    "@nestjs/testing": "^10.4.15",
+    "@types/express": "^5.0.0",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.2",
+    "@typescript-eslint/eslint-plugin": "^8.18.1",
+    "@typescript-eslint/parser": "^8.18.1",
+    "eslint": "^9.17.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.4.2",
+    "source-map-support": "^0.5.21",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.5",
+    "ts-loader": "^9.5.1",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.7.2"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": ".",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "src/**/*.(t|j)s"
+    ],
+    "coverageDirectory": "coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/services/orchestrator/src/app.module.ts
+++ b/services/orchestrator/src/app.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { validateEnv } from './common/config/env.schema';
+import { HealthModule } from './health/health.module';
+import { JobsModule } from './jobs/jobs.module';
+import { WorkersModule } from './workers/workers.module';
+
+class AppModuleBase {}
+
+export const AppModule = Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validate: validateEnv,
+    }),
+    HealthModule,
+    WorkersModule,
+    JobsModule,
+  ],
+})(AppModuleBase) as typeof AppModuleBase;

--- a/services/orchestrator/src/app.module.ts
+++ b/services/orchestrator/src/app.module.ts
@@ -6,9 +6,7 @@ import { HealthModule } from './health/health.module';
 import { JobsModule } from './jobs/jobs.module';
 import { WorkersModule } from './workers/workers.module';
 
-class AppModuleBase {}
-
-export const AppModule = Module({
+@Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
@@ -18,4 +16,5 @@ export const AppModule = Module({
     WorkersModule,
     JobsModule,
   ],
-})(AppModuleBase) as typeof AppModuleBase;
+})
+export class AppModule {}

--- a/services/orchestrator/src/common/config/env.schema.ts
+++ b/services/orchestrator/src/common/config/env.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const portSchema = z.coerce.number().int().min(1).max(65_535);
+
+export const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  ORCHESTRATOR_PORT: portSchema.default(4100),
+  ORCHESTRATOR_VERSION: z.string().min(1).default('0.1.0'),
+  ALLOWED_ORIGINS: z.string().default('http://localhost:3000'),
+  JWT_SECRET: z.string().min(24, 'JWT_SECRET must be at least 24 characters'),
+  DATABASE_URL: z.string().url().or(z.string().startsWith('postgresql://')),
+});
+
+export type EnvConfig = z.infer<typeof envSchema>;
+
+export function validateEnv(config: Record<string, unknown>): EnvConfig {
+  const parsed = envSchema.safeParse(config);
+
+  if (!parsed.success) {
+    const errors = parsed.error.issues
+      .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+      .join('; ');
+
+    throw new Error(`Invalid orchestrator environment: ${errors}`);
+  }
+
+  return parsed.data;
+}

--- a/services/orchestrator/src/health/health.controller.spec.ts
+++ b/services/orchestrator/src/health/health.controller.spec.ts
@@ -1,0 +1,26 @@
+import { ConfigService } from '@nestjs/config';
+
+import { HealthService } from './health.service';
+
+describe('HealthService', () => {
+  it('returns health metadata', () => {
+    const config = {
+      get: (key: string) => {
+        const values: Record<string, string> = {
+          ORCHESTRATOR_VERSION: '0.1.0',
+          NODE_ENV: 'test',
+        };
+        return values[key];
+      },
+    } as ConfigService<any, true>;
+
+    const service = new HealthService(config);
+
+    expect(service.getHealth()).toMatchObject({
+      status: 'ok',
+      service: 'hashnhedge-orchestrator',
+      version: '0.1.0',
+      environment: 'test',
+    });
+  });
+});

--- a/services/orchestrator/src/health/health.controller.ts
+++ b/services/orchestrator/src/health/health.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+import { HealthResponse, HealthService } from './health.service';
+
+@ApiTags('health')
+@Controller('health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  @ApiOkResponse({ description: 'HashNHedge orchestrator health status' })
+  getHealth(): HealthResponse {
+    return this.healthService.getHealth();
+  }
+}

--- a/services/orchestrator/src/health/health.module.ts
+++ b/services/orchestrator/src/health/health.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+
+class HealthModuleBase {}
+
+export const HealthModule = Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})(HealthModuleBase) as typeof HealthModuleBase;

--- a/services/orchestrator/src/health/health.module.ts
+++ b/services/orchestrator/src/health/health.module.ts
@@ -3,9 +3,8 @@ import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 
-class HealthModuleBase {}
-
-export const HealthModule = Module({
+@Module({
   controllers: [HealthController],
   providers: [HealthService],
-})(HealthModuleBase) as typeof HealthModuleBase;
+})
+export class HealthModule {}

--- a/services/orchestrator/src/health/health.service.ts
+++ b/services/orchestrator/src/health/health.service.ts
@@ -12,7 +12,8 @@ export interface HealthResponse {
   timestamp: string;
 }
 
-class HealthServiceBase {
+@Injectable()
+export class HealthService {
   constructor(private readonly config: ConfigService<EnvConfig, true>) {}
 
   getHealth(): HealthResponse {
@@ -26,5 +27,3 @@ class HealthServiceBase {
     };
   }
 }
-
-export const HealthService = Injectable()(HealthServiceBase) as typeof HealthServiceBase;

--- a/services/orchestrator/src/health/health.service.ts
+++ b/services/orchestrator/src/health/health.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { EnvConfig } from '../common/config/env.schema';
+
+export interface HealthResponse {
+  status: 'ok';
+  service: 'hashnhedge-orchestrator';
+  version: string;
+  environment: string;
+  uptimeSeconds: number;
+  timestamp: string;
+}
+
+class HealthServiceBase {
+  constructor(private readonly config: ConfigService<EnvConfig, true>) {}
+
+  getHealth(): HealthResponse {
+    return {
+      status: 'ok',
+      service: 'hashnhedge-orchestrator',
+      version: this.config.get('ORCHESTRATOR_VERSION', { infer: true }),
+      environment: this.config.get('NODE_ENV', { infer: true }),
+      uptimeSeconds: Math.floor(process.uptime()),
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
+export const HealthService = Injectable()(HealthServiceBase) as typeof HealthServiceBase;

--- a/services/orchestrator/src/jobs/dto/create-job.dto.ts
+++ b/services/orchestrator/src/jobs/dto/create-job.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsObject, IsOptional, IsString, Min, MinLength } from 'class-validator';
+
+export class CreateJobDto {
+  @ApiProperty({ example: 'ai-inference' })
+  @IsString()
+  @MinLength(3)
+  jobType!: string;
+
+  @ApiProperty({ example: 'Run LLM inference batch for vendor workload' })
+  @IsString()
+  @MinLength(3)
+  description!: string;
+
+  @ApiPropertyOptional({ example: 'vendor_123' })
+  @IsOptional()
+  @IsString()
+  requesterId?: string;
+
+  @ApiPropertyOptional({ example: { gpus: 1, memoryGb: 24, region: 'us-east' } })
+  @IsOptional()
+  @IsObject()
+  requirements?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ example: 3 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  maxRetries?: number;
+
+  @ApiPropertyOptional({ example: 300 })
+  @IsOptional()
+  @IsInt()
+  @Min(30)
+  leaseSeconds?: number;
+
+  @ApiPropertyOptional({ example: { model: 'llama', batch: 64 } })
+  @IsOptional()
+  @IsObject()
+  payload?: Record<string, unknown>;
+}

--- a/services/orchestrator/src/jobs/dto/lease-job.dto.ts
+++ b/services/orchestrator/src/jobs/dto/lease-job.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class LeaseJobDto {
+  @ApiProperty({ example: 'worker-rig-001' })
+  @IsString()
+  @MinLength(3)
+  workerId!: string;
+}

--- a/services/orchestrator/src/jobs/job-status.ts
+++ b/services/orchestrator/src/jobs/job-status.ts
@@ -1,0 +1,21 @@
+export enum JobStatus {
+  Queued = 'queued',
+  Assigned = 'assigned',
+  Running = 'running',
+  ProofSubmitted = 'proof_submitted',
+  Verified = 'verified',
+  Paid = 'paid',
+  Failed = 'failed',
+  RetryQueued = 'retry_queued',
+  DeadLettered = 'dead_lettered',
+  LeaseExpired = 'lease_expired',
+}
+
+export const terminalJobStatuses = new Set<JobStatus>([
+  JobStatus.Paid,
+  JobStatus.DeadLettered,
+]);
+
+export function isTerminalJobStatus(status: JobStatus): boolean {
+  return terminalJobStatuses.has(status);
+}

--- a/services/orchestrator/src/jobs/jobs.controller.ts
+++ b/services/orchestrator/src/jobs/jobs.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+import { CreateJobDto } from './dto/create-job.dto';
+import { LeaseJobDto } from './dto/lease-job.dto';
+import { JobRecord, JobsService } from './jobs.service';
+
+@ApiTags('jobs')
+@Controller('jobs')
+export class JobsController {
+  constructor(private readonly jobsService: JobsService) {}
+
+  @Post()
+  @ApiCreatedResponse({ description: 'Job queued' })
+  createJob(@Body() dto: CreateJobDto): JobRecord {
+    return this.jobsService.createJob(dto);
+  }
+
+  @Get()
+  @ApiOkResponse({ description: 'Jobs' })
+  listJobs(): JobRecord[] {
+    return this.jobsService.listJobs();
+  }
+
+  @Get(':jobId')
+  @ApiOkResponse({ description: 'Job details' })
+  getJob(@Param('jobId') jobId: string): JobRecord {
+    return this.jobsService.getJob(jobId);
+  }
+
+  @Post('lease-next')
+  @ApiOkResponse({ description: 'Next queued job leased to worker' })
+  leaseNextJob(@Body() dto: LeaseJobDto): JobRecord {
+    return this.jobsService.leaseNextJob(dto.workerId);
+  }
+
+  @Post(':jobId/running')
+  @ApiOkResponse({ description: 'Job marked running' })
+  markRunning(@Param('jobId') jobId: string): JobRecord {
+    return this.jobsService.markRunning(jobId);
+  }
+}

--- a/services/orchestrator/src/jobs/jobs.module.ts
+++ b/services/orchestrator/src/jobs/jobs.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { JobsController } from './jobs.controller';
+import { JobsService } from './jobs.service';
+import { WorkersModule } from '../workers/workers.module';
+
+@Module({
+  imports: [WorkersModule],
+  controllers: [JobsController],
+  providers: [JobsService],
+  exports: [JobsService],
+})
+export class JobsModule {}

--- a/services/orchestrator/src/jobs/jobs.service.ts
+++ b/services/orchestrator/src/jobs/jobs.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { CreateJobDto } from './dto/create-job.dto';
+import { JobStatus } from './job-status';
+
+export interface JobRecord {
+  id: string;
+  jobType: string;
+  description: string;
+  status: JobStatus;
+  assignedWorkerId?: string;
+  leaseId?: string;
+  leaseExpiresAt?: string;
+  retryCount: number;
+  maxRetries: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+@Injectable()
+export class JobsService {
+  private readonly jobs = new Map<string, JobRecord>();
+  private sequence = 0;
+
+  createJob(dto: CreateJobDto): JobRecord {
+    const now = new Date().toISOString();
+    const job: JobRecord = {
+      id: this.nextId('job'),
+      jobType: dto.jobType,
+      description: dto.description,
+      status: JobStatus.Queued,
+      retryCount: 0,
+      maxRetries: dto.maxRetries ?? 3,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.jobs.set(job.id, job);
+    return job;
+  }
+
+  listJobs(): JobRecord[] {
+    return Array.from(this.jobs.values());
+  }
+
+  getJob(jobId: string): JobRecord {
+    const job = this.jobs.get(jobId);
+
+    if (!job) {
+      throw new NotFoundException(`Job ${jobId} not found`);
+    }
+
+    return job;
+  }
+
+  leaseNextJob(workerId: string): JobRecord {
+    const job = this.listJobs().find((candidate) => candidate.status === JobStatus.Queued);
+
+    if (!job) {
+      throw new NotFoundException('No queued jobs are available');
+    }
+
+    const now = new Date();
+    const updated: JobRecord = {
+      ...job,
+      status: JobStatus.Assigned,
+      assignedWorkerId: workerId,
+      leaseId: this.nextId('lease'),
+      leaseExpiresAt: new Date(now.getTime() + 300000).toISOString(),
+      updatedAt: now.toISOString(),
+    };
+
+    this.jobs.set(job.id, updated);
+    return updated;
+  }
+
+  markRunning(jobId: string): JobRecord {
+    const job = this.getJob(jobId);
+    const updated = { ...job, status: JobStatus.Running, updatedAt: new Date().toISOString() };
+    this.jobs.set(job.id, updated);
+    return updated;
+  }
+
+  private nextId(prefix: string): string {
+    this.sequence += 1;
+    return `${prefix}_${Date.now()}_${this.sequence}`;
+  }
+}

--- a/services/orchestrator/src/main.ts
+++ b/services/orchestrator/src/main.ts
@@ -1,0 +1,58 @@
+import { Logger, ValidationPipe } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import helmet from 'helmet';
+
+import { AppModule } from './app.module';
+import { EnvConfig } from './common/config/env.schema';
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  const logger = new Logger('Bootstrap');
+  const config = app.get(ConfigService<EnvConfig, true>);
+
+  app.use(helmet());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
+  const allowedOrigins = config
+    .get('ALLOWED_ORIGINS', { infer: true })
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  app.enableCors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error('Origin not allowed by HashNHedge orchestrator CORS policy'));
+    },
+    credentials: true,
+  });
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('HashNHedge Orchestrator API')
+    .setDescription('Production control-plane API for workers, jobs, vendors, payments, and Solana coordination.')
+    .setVersion(config.get('ORCHESTRATOR_VERSION', { infer: true }))
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('docs', app, document);
+
+  const port = config.get('ORCHESTRATOR_PORT', { infer: true });
+  await app.listen(port, '0.0.0.0');
+
+  logger.log(`HashNHedge orchestrator listening on port ${port}`);
+}
+
+void bootstrap();

--- a/services/orchestrator/src/workers/dto/heartbeat.dto.ts
+++ b/services/orchestrator/src/workers/dto/heartbeat.dto.ts
@@ -1,0 +1,33 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsObject, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class HeartbeatDto {
+  @ApiPropertyOptional({ example: 'running' })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({ example: 87.5 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  gpuUtilizationPercent?: number;
+
+  @ApiPropertyOptional({ example: 173000000 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  hashrate?: number;
+
+  @ApiPropertyOptional({ example: 2 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  activeJobs?: number;
+
+  @ApiPropertyOptional({ example: { temperatureC: 68, powerWatts: 315 } })
+  @IsOptional()
+  @IsObject()
+  telemetry?: Record<string, unknown>;
+}

--- a/services/orchestrator/src/workers/dto/register-worker.dto.ts
+++ b/services/orchestrator/src/workers/dto/register-worker.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsBoolean, IsInt, IsObject, IsOptional, IsString, Max, Min, MinLength } from 'class-validator';
+
+export class RegisterWorkerDto {
+  @ApiProperty({ example: 'worker-rig-001' })
+  @IsString()
+  @MinLength(3)
+  workerName!: string;
+
+  @ApiProperty({ example: 'GCKbEgD4VSLtkwt57At7pWscaxaQ2gBZtTQE2hqr3Yrc' })
+  @IsString()
+  @MinLength(32)
+  walletAddress!: string;
+
+  @ApiPropertyOptional({ example: ['mining', 'ai-inference', 'general-compute'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  capabilities?: string[];
+
+  @ApiPropertyOptional({ example: 4 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(256)
+  gpuCount?: number;
+
+  @ApiPropertyOptional({ example: 'NVIDIA RTX 4090' })
+  @IsOptional()
+  @IsString()
+  gpuModel?: string;
+
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
+  @IsBoolean()
+  acceptsLeasedJobs?: boolean;
+
+  @ApiPropertyOptional({ example: { region: 'us-east', memoryGb: 96 } })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/services/orchestrator/src/workers/workers.controller.ts
+++ b/services/orchestrator/src/workers/workers.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+import { HeartbeatDto } from './dto/heartbeat.dto';
+import { RegisterWorkerDto } from './dto/register-worker.dto';
+import { WorkerRecord, WorkersService } from './workers.service';
+
+@ApiTags('workers')
+@Controller('workers')
+export class WorkersController {
+  constructor(private readonly workersService: WorkersService) {}
+
+  @Post()
+  @ApiCreatedResponse({ description: 'Worker registered or refreshed' })
+  registerWorker(@Body() dto: RegisterWorkerDto): WorkerRecord {
+    return this.workersService.registerWorker(dto);
+  }
+
+  @Get()
+  @ApiOkResponse({ description: 'Registered workers' })
+  listWorkers(): WorkerRecord[] {
+    return this.workersService.listWorkers();
+  }
+
+  @Get(':workerId')
+  @ApiOkResponse({ description: 'Worker details' })
+  getWorker(@Param('workerId') workerId: string): WorkerRecord {
+    return this.workersService.getWorker(workerId);
+  }
+
+  @Post(':workerId/heartbeat')
+  @ApiOkResponse({ description: 'Worker heartbeat accepted' })
+  heartbeat(@Param('workerId') workerId: string, @Body() dto: HeartbeatDto): WorkerRecord {
+    return this.workersService.heartbeat(workerId, dto);
+  }
+}

--- a/services/orchestrator/src/workers/workers.module.ts
+++ b/services/orchestrator/src/workers/workers.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WorkersController } from './workers.controller';
+import { WorkersService } from './workers.service';
+
+@Module({
+  controllers: [WorkersController],
+  providers: [WorkersService],
+  exports: [WorkersService],
+})
+export class WorkersModule {}

--- a/services/orchestrator/src/workers/workers.service.ts
+++ b/services/orchestrator/src/workers/workers.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { HeartbeatDto } from './dto/heartbeat.dto';
+import { RegisterWorkerDto } from './dto/register-worker.dto';
+
+export interface WorkerRecord {
+  id: string;
+  workerName: string;
+  walletAddress: string;
+  capabilities: string[];
+  gpuCount: number;
+  gpuModel?: string;
+  acceptsLeasedJobs: boolean;
+  status: string;
+  metadata: Record<string, unknown>;
+  lastHeartbeatAt: string;
+  createdAt: string;
+  telemetry?: Record<string, unknown>;
+}
+
+@Injectable()
+export class WorkersService {
+  private readonly workers = new Map<string, WorkerRecord>();
+
+  registerWorker(dto: RegisterWorkerDto): WorkerRecord {
+    const now = new Date().toISOString();
+    const id = this.normalizeWorkerId(dto.workerName);
+    const existing = this.workers.get(id);
+
+    const worker: WorkerRecord = {
+      id,
+      workerName: dto.workerName,
+      walletAddress: dto.walletAddress,
+      capabilities: dto.capabilities ?? ['mining'],
+      gpuCount: dto.gpuCount ?? 0,
+      gpuModel: dto.gpuModel,
+      acceptsLeasedJobs: dto.acceptsLeasedJobs ?? true,
+      status: existing?.status ?? 'registered',
+      metadata: dto.metadata ?? {},
+      createdAt: existing?.createdAt ?? now,
+      lastHeartbeatAt: now,
+      telemetry: existing?.telemetry,
+    };
+
+    this.workers.set(id, worker);
+    return worker;
+  }
+
+  listWorkers(): WorkerRecord[] {
+    return Array.from(this.workers.values()).sort((a, b) => a.workerName.localeCompare(b.workerName));
+  }
+
+  getWorker(workerId: string): WorkerRecord {
+    const worker = this.workers.get(workerId);
+
+    if (!worker) {
+      throw new NotFoundException(`Worker ${workerId} not found`);
+    }
+
+    return worker;
+  }
+
+  heartbeat(workerId: string, dto: HeartbeatDto): WorkerRecord {
+    const worker = this.getWorker(workerId);
+
+    const updated: WorkerRecord = {
+      ...worker,
+      status: dto.status ?? 'active',
+      lastHeartbeatAt: new Date().toISOString(),
+      telemetry: {
+        ...(worker.telemetry ?? {}),
+        ...(dto.telemetry ?? {}),
+        gpuUtilizationPercent: dto.gpuUtilizationPercent,
+        hashrate: dto.hashrate,
+        activeJobs: dto.activeJobs,
+      },
+    };
+
+    this.workers.set(workerId, updated);
+    return updated;
+  }
+
+  private normalizeWorkerId(workerName: string): string {
+    return workerName.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+  }
+}

--- a/services/orchestrator/test/health.e2e-spec.ts
+++ b/services/orchestrator/test/health.e2e-spec.ts
@@ -1,0 +1,37 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+
+describe('Health endpoint', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret-that-is-long-enough';
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://user:password@localhost:5432/hashnhedge';
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns orchestrator health', async () => {
+    await request(app.getHttpServer())
+      .get('/health')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).toMatchObject({
+          status: 'ok',
+          service: 'hashnhedge-orchestrator',
+        });
+      });
+  });
+});

--- a/services/orchestrator/test/workers-jobs.e2e-spec.ts
+++ b/services/orchestrator/test/workers-jobs.e2e-spec.ts
@@ -1,0 +1,49 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+
+describe('Worker and job loop', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'test-secret-that-is-long-enough';
+    process.env.DATABASE_URL = 'postgresql://user:password@localhost:5432/hashnhedge';
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('registers a worker, queues a job, and leases the job', async () => {
+    await request(app.getHttpServer())
+      .post('/workers')
+      .send({
+        workerName: 'worker-rig-001',
+        walletAddress: 'GCKbEgD4VSLtkwt57At7pWscaxaQ2gBZtTQE2hqr3Yrc',
+        capabilities: ['mining', 'ai-inference'],
+        gpuCount: 2,
+      })
+      .expect(201);
+
+    const jobResponse = await request(app.getHttpServer())
+      .post('/jobs')
+      .send({ jobType: 'ai-inference', description: 'Inference batch' })
+      .expect(201);
+
+    expect(jobResponse.body.status).toBe('queued');
+
+    const leaseResponse = await request(app.getHttpServer())
+      .post('/jobs/lease-next')
+      .send({ workerId: 'worker-rig-001' })
+      .expect(201);
+
+    expect(leaseResponse.body.status).toBe('assigned');
+    expect(leaseResponse.body.assignedWorkerId).toBe('worker-rig-001');
+  });
+});

--- a/services/orchestrator/tsconfig.build.json
+++ b/services/orchestrator/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/services/orchestrator/tsconfig.json
+++ b/services/orchestrator/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2022",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "strictBindCallApply": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@app/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Starts the real implementation phase for the HashNHedge production control plane.

## Added

- NestJS orchestrator package under `services/orchestrator`
- strict TypeScript config and Nest CLI config
- environment template and Zod-based boot-time config validation
- secure bootstrap with Helmet, CORS allowlist, validation pipe, and Swagger docs
- `GET /health` endpoint
- worker registry endpoints:
  - `POST /workers`
  - `GET /workers`
  - `GET /workers/:workerId`
  - `POST /workers/:workerId/heartbeat`
- job scheduler foundation endpoints:
  - `POST /jobs`
  - `GET /jobs`
  - `GET /jobs/:jobId`
  - `POST /jobs/lease-next`
  - `POST /jobs/:jobId/running`
- job lifecycle TypeScript enum
- initial e2e/unit tests

## Notes

The worker and job stores are intentionally in-memory in this first pass. The goal is to lock down module boundaries, API contracts, validation, lifecycle states, and test harness before wiring PostgreSQL/Prisma persistence.

Progresses #33 and #34.