### PR TITLE
Add orchestrator lease recovery and retry policy

### DIFF
--- a/services/orchestrator/README.md
+++ b/services/orchestrator/README.md
@@ -38,6 +38,19 @@ Initial persisted models:
 
 `JobEvent` records lifecycle transitions for auditability.
 
+## Job reliability behavior
+
+The scheduler now has service-level support for:
+
+- lease expiry detection
+- retry counters
+- requeueing retryable jobs
+- dead-lettering exhausted jobs
+- proof/result metadata submission
+- failure transition auditing
+
+The next API layer should expose these controls through admin/worker-scoped routes after auth and RBAC land.
+
 ## Endpoints
 
 - `GET /health`

--- a/services/orchestrator/src/jobs/dto/fail-job.dto.ts
+++ b/services/orchestrator/src/jobs/dto/fail-job.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class FailJobDto {
+  @ApiProperty({ example: 'worker_runtime_error' })
+  @IsString()
+  @MinLength(3)
+  reason!: string;
+}

--- a/services/orchestrator/src/jobs/dto/submit-proof.dto.ts
+++ b/services/orchestrator/src/jobs/dto/submit-proof.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MinLength } from 'class-validator';
+
+export class SubmitProofDto {
+  @ApiProperty({ example: 'sha256:ab12cd34ef56' })
+  @IsString()
+  @MinLength(8)
+  proofHash!: string;
+
+  @ApiPropertyOptional({ example: 's3://hashnhedge-results/job_123/result.json' })
+  @IsOptional()
+  @IsString()
+  resultUri?: string;
+}

--- a/services/orchestrator/src/jobs/jobs.service.spec.ts
+++ b/services/orchestrator/src/jobs/jobs.service.spec.ts
@@ -1,0 +1,86 @@
+import { JobStatus } from '@prisma/client';
+
+import { JobsService } from './jobs.service';
+
+function createPrismaMock(seedJobs: any[]) {
+  const jobs = new Map(seedJobs.map((job) => [job.id, job]));
+  const events: any[] = [];
+
+  const prisma = {
+    $transaction: jest.fn(async (callback: any) => callback(prisma)),
+    job: {
+      findMany: jest.fn(async () => Array.from(jobs.values())),
+      update: jest.fn(async ({ where, data }: any) => {
+        const updated = { ...jobs.get(where.id), ...data };
+        jobs.set(where.id, updated);
+        return updated;
+      }),
+    },
+    jobEvent: {
+      create: jest.fn(async ({ data }: any) => {
+        events.push(data);
+        return data;
+      }),
+    },
+  };
+
+  return { prisma, jobs, events };
+}
+
+describe('JobsService recovery', () => {
+  it('requeues retryable expired jobs', async () => {
+    const expiredAt = new Date('2026-01-01T00:00:00.000Z');
+    const { prisma, jobs, events } = createPrismaMock([
+      {
+        id: 'job_1',
+        status: JobStatus.ASSIGNED,
+        retryCount: 0,
+        maxRetries: 3,
+        assignedWorkerId: 'worker_1',
+        leaseExpiresAt: expiredAt,
+      },
+    ]);
+
+    const service = new JobsService(prisma as any);
+    const summary = await service.recoverExpiredLeases(new Date('2026-01-01T00:05:00.000Z'));
+
+    expect(summary).toEqual({ recovered: 1, deadLettered: 0 });
+    expect(jobs.get('job_1')).toMatchObject({
+      status: JobStatus.QUEUED,
+      retryCount: 1,
+      assignedWorkerId: null,
+      leaseId: null,
+      leaseExpiresAt: null,
+    });
+    expect(events[0]).toMatchObject({
+      jobId: 'job_1',
+      fromStatus: JobStatus.ASSIGNED,
+      toStatus: JobStatus.QUEUED,
+      actorId: 'worker_1',
+    });
+  });
+
+  it('dead letters exhausted expired jobs', async () => {
+    const expiredAt = new Date('2026-01-01T00:00:00.000Z');
+    const { prisma, jobs } = createPrismaMock([
+      {
+        id: 'job_2',
+        status: JobStatus.RUNNING,
+        retryCount: 3,
+        maxRetries: 3,
+        assignedWorkerId: 'worker_2',
+        leaseExpiresAt: expiredAt,
+      },
+    ]);
+
+    const service = new JobsService(prisma as any);
+    const summary = await service.recoverExpiredLeases(new Date('2026-01-01T00:05:00.000Z'));
+
+    expect(summary).toEqual({ recovered: 0, deadLettered: 1 });
+    expect(jobs.get('job_2')).toMatchObject({
+      status: JobStatus.DEAD_LETTERED,
+      retryCount: 4,
+      assignedWorkerId: null,
+    });
+  });
+});

--- a/services/orchestrator/src/jobs/jobs.service.ts
+++ b/services/orchestrator/src/jobs/jobs.service.ts
@@ -1,10 +1,15 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { Job, JobStatus, Prisma } from '@prisma/client';
 
 import { PrismaService } from '../database/prisma.service';
 import { CreateJobDto } from './dto/create-job.dto';
 
 export type JobRecord = Job;
+
+export interface RecoverySummary {
+  recovered: number;
+  deadLettered: number;
+}
 
 @Injectable()
 export class JobsService {
@@ -77,16 +82,7 @@ export class JobsService {
         },
       });
 
-      await tx.jobEvent.create({
-        data: {
-          id: this.nextId('event'),
-          jobId: job.id,
-          fromStatus: job.status,
-          toStatus: JobStatus.ASSIGNED,
-          actorId: workerId,
-          metadata: this.toJson({ reason: 'job_leased' }),
-        },
-      });
+      await this.createEvent(tx, job.id, job.status, JobStatus.ASSIGNED, workerId, { reason: 'job_leased' });
 
       return updated;
     });
@@ -95,24 +91,146 @@ export class JobsService {
   async markRunning(jobId: string): Promise<JobRecord> {
     const job = await this.getJob(jobId);
 
+    if (job.status !== JobStatus.ASSIGNED) {
+      throw new ConflictException(`Job ${jobId} must be ASSIGNED before it can run`);
+    }
+
     return this.prisma.$transaction(async (tx) => {
       const updated = await tx.job.update({
         where: { id: jobId },
         data: { status: JobStatus.RUNNING },
       });
 
-      await tx.jobEvent.create({
+      await this.createEvent(tx, jobId, job.status, JobStatus.RUNNING, job.assignedWorkerId, { reason: 'worker_started' });
+
+      return updated;
+    });
+  }
+
+  async submitProof(jobId: string, proofHash: string, resultUri?: string): Promise<JobRecord> {
+    const job = await this.getJob(jobId);
+
+    if (job.status !== JobStatus.RUNNING) {
+      throw new ConflictException(`Job ${jobId} must be RUNNING before proof submission`);
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.job.update({
+        where: { id: jobId },
         data: {
-          id: this.nextId('event'),
-          jobId,
-          fromStatus: job.status,
-          toStatus: JobStatus.RUNNING,
-          actorId: job.assignedWorkerId,
-          metadata: this.toJson({ reason: 'worker_started' }),
+          status: JobStatus.PROOF_SUBMITTED,
+          proofHash,
+          resultUri,
         },
       });
 
+      await this.createEvent(tx, jobId, job.status, JobStatus.PROOF_SUBMITTED, job.assignedWorkerId, {
+        reason: 'proof_submitted',
+        proofHash,
+      });
+
       return updated;
+    });
+  }
+
+  async failJob(jobId: string, reason: string): Promise<JobRecord> {
+    const job = await this.getJob(jobId);
+    const retryCount = job.retryCount + 1;
+    const nextStatus = retryCount <= job.maxRetries ? JobStatus.RETRY_QUEUED : JobStatus.DEAD_LETTERED;
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.job.update({
+        where: { id: jobId },
+        data: {
+          status: nextStatus,
+          retryCount,
+          assignedWorkerId: null,
+          leaseId: null,
+          leaseExpiresAt: null,
+        },
+      });
+
+      await this.createEvent(tx, jobId, job.status, nextStatus, job.assignedWorkerId, { reason });
+
+      if (nextStatus === JobStatus.RETRY_QUEUED) {
+        const requeued = await tx.job.update({
+          where: { id: jobId },
+          data: { status: JobStatus.QUEUED },
+        });
+
+        await this.createEvent(tx, jobId, nextStatus, JobStatus.QUEUED, job.assignedWorkerId, {
+          reason: 'retry_requeued',
+          retryCount,
+        });
+
+        return requeued;
+      }
+
+      return updated;
+    });
+  }
+
+  async recoverExpiredLeases(now = new Date()): Promise<RecoverySummary> {
+    const expiredJobs = await this.prisma.job.findMany({
+      where: {
+        status: { in: [JobStatus.ASSIGNED, JobStatus.RUNNING] },
+        leaseExpiresAt: { lt: now },
+      },
+      orderBy: { leaseExpiresAt: 'asc' },
+    });
+
+    let recovered = 0;
+    let deadLettered = 0;
+
+    for (const job of expiredJobs) {
+      const retryCount = job.retryCount + 1;
+      const nextStatus = retryCount <= job.maxRetries ? JobStatus.QUEUED : JobStatus.DEAD_LETTERED;
+
+      await this.prisma.$transaction(async (tx) => {
+        await tx.job.update({
+          where: { id: job.id },
+          data: {
+            status: nextStatus,
+            retryCount,
+            assignedWorkerId: null,
+            leaseId: null,
+            leaseExpiresAt: null,
+          },
+        });
+
+        await this.createEvent(tx, job.id, job.status, nextStatus, job.assignedWorkerId, {
+          reason: 'lease_expired',
+          retryCount,
+        });
+      });
+
+      if (nextStatus === JobStatus.QUEUED) {
+        recovered += 1;
+      } else {
+        deadLettered += 1;
+      }
+    }
+
+    return { recovered, deadLettered };
+  }
+
+  private async createEvent(
+    tx: Prisma.TransactionClient,
+    jobId: string,
+    fromStatus: JobStatus | null,
+    toStatus: JobStatus,
+    actorId: string | null | undefined,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    await tx.jobEvent.create({
+      data: {
+        id: this.nextId('event'),
+        jobId,
+        fromStatus,
+        toStatus,
+        actorId,
+        metadata: this.toJson(metadata),
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

Adds the next reliability layer for the HashNHedge orchestrator job scheduler.

## Added

- lease expiry recovery logic
- retry counter handling
- automatic requeueing for retryable expired jobs
- dead-letter handling when retry budget is exhausted
- stricter transition guard for `ASSIGNED -> RUNNING`
- service methods for proof/result metadata submission
- service method for explicit job failure policy
- failure/proof DTOs for the next API layer
- job lifecycle audit events for recovery, proof, and failure transitions
- unit tests for retryable lease recovery and dead-letter behavior
- README documentation for scheduler reliability behavior

## Notes

The recovery/failure/proof service methods are in place now. I intentionally left the public route exposure minimal until auth/RBAC lands, so high-risk operational controls can be scoped properly instead of shipped as unauthenticated public endpoints.

Progresses #34.