### PR TITLE
Add orchestrator request signing and replay protection

### DIFF
--- a/services/orchestrator/docs/request-signing.md
+++ b/services/orchestrator/docs/request-signing.md
@@ -1,0 +1,46 @@
+# HashNHedge Request Signing
+
+The orchestrator supports HMAC request signing for high-risk worker, vendor, and admin operations.
+
+## Headers
+
+- `x-hnh-role`: one of `admin`, `worker`, or `vendor`
+- `x-hnh-api-key`: scoped API key for the role
+- `x-hnh-timestamp`: Unix timestamp in seconds
+- `x-hnh-nonce`: unique nonce for the actor and replay window
+- `x-hnh-signature`: hex-encoded HMAC-SHA256 signature
+
+## Payload format
+
+The signature payload is:
+
+```text
+METHOD|PATH|TIMESTAMP|NONCE|BODY
+```
+
+Where:
+
+- `METHOD` is uppercase HTTP method
+- `PATH` is the original URL path including query string
+- `TIMESTAMP` is the timestamp header
+- `NONCE` is the nonce header
+- `BODY` is JSON-stringified request body, or an empty string when no body exists
+
+## Replay window
+
+Requests are accepted only when the timestamp is within five minutes of server time.
+
+Each nonce can be used once per role/API-key scope during the replay window.
+
+## Current implementation
+
+This PR adds:
+
+- signature header constants
+- signature service
+- nonce store
+- request signing guard
+- route decorator for signed endpoints
+- unit tests for HMAC signing
+
+The nonce store is in-memory for the first pass. It should be replaced with Redis before multi-instance production deployment.

--- a/services/orchestrator/src/auth/auth.module.ts
+++ b/services/orchestrator/src/auth/auth.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 
 import { AuthGuard } from './auth.guard';
+import { NonceStore } from './nonce.store';
+import { RequestSigningGuard } from './request-signing.guard';
+import { SignatureService } from './signature.service';
 
-@Module({
-  providers: [AuthGuard],
-  exports: [AuthGuard],
-})
+@Module({ providers: [AuthGuard, RequestSigningGuard, NonceStore, SignatureService], exports: [AuthGuard, RequestSigningGuard, NonceStore, SignatureService] })
 export class AuthModule {}

--- a/services/orchestrator/src/auth/nonce.store.ts
+++ b/services/orchestrator/src/auth/nonce.store.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+
+interface NonceEntry {
+  expiresAt: number;
+}
+
+@Injectable()
+export class NonceStore {
+  private readonly nonces = new Map<string, NonceEntry>();
+
+  remember(scope: string, nonce: string, ttlSeconds: number): boolean {
+    this.prune();
+
+    const key = `${scope}:${nonce}`;
+    if (this.nonces.has(key)) {
+      return false;
+    }
+
+    this.nonces.set(key, { expiresAt: Date.now() + ttlSeconds * 1000 });
+    return true;
+  }
+
+  private prune(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.nonces.entries()) {
+      if (entry.expiresAt <= now) {
+        this.nonces.delete(key);
+      }
+    }
+  }
+}

--- a/services/orchestrator/src/auth/request-signing.guard.ts
+++ b/services/orchestrator/src/auth/request-signing.guard.ts
@@ -1,0 +1,83 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+
+import { EnvConfig } from '../common/config/env.schema';
+import { apiKeyHeaderName, Role, roleHeaderName } from './roles';
+import { signedRouteMetadataKey } from './signed.decorator';
+import { NonceStore } from './nonce.store';
+import { maxSignatureAgeSeconds, nonceHeaderName, signatureHeaderName, timestampHeaderName } from './signature.headers';
+import { SignatureService } from './signature.service';
+
+@Injectable()
+export class RequestSigningGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly config: ConfigService<EnvConfig, true>,
+    private readonly nonceStore: NonceStore,
+    private readonly signatures: SignatureService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiresSignature = this.reflector.getAllAndOverride<boolean>(signedRouteMetadataKey, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiresSignature) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const role = request.header(roleHeaderName) as Role | undefined;
+    const apiKey = request.header(apiKeyHeaderName);
+    const timestamp = request.header(timestampHeaderName);
+    const nonce = request.header(nonceHeaderName);
+    const signature = request.header(signatureHeaderName);
+
+    if (!role || !apiKey || !timestamp || !nonce || !signature) {
+      throw new UnauthorizedException('Missing HashNHedge signing headers');
+    }
+
+    this.assertFreshTimestamp(timestamp);
+
+    if (!this.nonceStore.remember(`${role}:${apiKey}`, nonce, maxSignatureAgeSeconds)) {
+      throw new UnauthorizedException('Replay detected for HashNHedge signed request');
+    }
+
+    const secret = this.getExpectedApiKey(role);
+    const payload = this.signatures.buildPayload(request.method, request.originalUrl ?? request.url, timestamp, nonce, request.body);
+
+    if (!this.signatures.verify(payload, secret, signature)) {
+      throw new UnauthorizedException('Invalid HashNHedge request signature');
+    }
+
+    return true;
+  }
+
+  private assertFreshTimestamp(timestamp: string): void {
+    const timestampMs = Number(timestamp) * 1000;
+
+    if (!Number.isFinite(timestampMs)) {
+      throw new UnauthorizedException('Invalid HashNHedge timestamp');
+    }
+
+    const ageSeconds = Math.abs(Date.now() - timestampMs) / 1000;
+
+    if (ageSeconds > maxSignatureAgeSeconds) {
+      throw new UnauthorizedException('HashNHedge request timestamp is outside replay window');
+    }
+  }
+
+  private getExpectedApiKey(role: Role): string {
+    switch (role) {
+      case Role.Admin:
+        return this.config.get('ADMIN_API_KEY', { infer: true });
+      case Role.Worker:
+        return this.config.get('WORKER_API_KEY', { infer: true });
+      case Role.Vendor:
+        return this.config.get('VENDOR_API_KEY', { infer: true });
+    }
+  }
+}

--- a/services/orchestrator/src/auth/signature.headers.ts
+++ b/services/orchestrator/src/auth/signature.headers.ts
@@ -1,0 +1,5 @@
+export const signatureHeaderName = 'x-hnh-signature';
+export const timestampHeaderName = 'x-hnh-timestamp';
+export const nonceHeaderName = 'x-hnh-nonce';
+
+export const maxSignatureAgeSeconds = 300;

--- a/services/orchestrator/src/auth/signature.service.spec.ts
+++ b/services/orchestrator/src/auth/signature.service.spec.ts
@@ -1,0 +1,19 @@
+import { SignatureService } from './signature.service';
+
+describe('SignatureService', () => {
+  const service = new SignatureService();
+
+  it('verifies matching signatures', () => {
+    const payload = service.buildPayload('POST', '/workers', '1760000000', 'nonce-1', { ok: true });
+    const signature = service.sign(payload, 'secret-that-is-long-enough');
+
+    expect(service.verify(payload, 'secret-that-is-long-enough', signature)).toBe(true);
+  });
+
+  it('rejects mismatched signatures', () => {
+    const payload = service.buildPayload('POST', '/workers', '1760000000', 'nonce-1', { ok: true });
+    const signature = service.sign(payload, 'secret-that-is-long-enough');
+
+    expect(service.verify(payload, 'different-secret-that-is-long-enough', signature)).toBe(false);
+  });
+});

--- a/services/orchestrator/src/auth/signature.service.ts
+++ b/services/orchestrator/src/auth/signature.service.ts
@@ -1,0 +1,26 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SignatureService {
+  buildPayload(method: string, path: string, timestamp: string, nonce: string, body: unknown): string {
+    const normalizedBody = body === undefined ? '' : JSON.stringify(body ?? {});
+    return [method.toUpperCase(), path, timestamp, nonce, normalizedBody].join('|');
+  }
+
+  sign(payload: string, secret: string): string {
+    return createHmac('sha256', secret).update(payload).digest('hex');
+  }
+
+  verify(payload: string, secret: string, signature: string): boolean {
+    const expected = this.sign(payload, secret);
+    const expectedBuffer = Buffer.from(expected, 'hex');
+    const actualBuffer = Buffer.from(signature, 'hex');
+
+    if (expectedBuffer.length !== actualBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(expectedBuffer, actualBuffer);
+  }
+}

--- a/services/orchestrator/src/auth/signed.decorator.ts
+++ b/services/orchestrator/src/auth/signed.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const signedRouteMetadataKey = 'hnh_signed_route';
+
+export const SignedRoute = () => SetMetadata(signedRouteMetadataKey, true);

--- a/services/orchestrator/src/workers/workers.controller.ts
+++ b/services/orchestrator/src/workers/workers.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 import { AuthGuard } from '../auth/auth.guard';
+import { RequestSigningGuard } from '../auth/request-signing.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../auth/roles';
 import { HeartbeatDto } from './dto/heartbeat.dto';
@@ -11,7 +12,7 @@ import { WorkerRecord, WorkersService } from './workers.service';
 @ApiTags('workers')
 @ApiSecurity('x-hnh-api-key')
 @Controller('workers')
-@UseGuards(AuthGuard)
+@UseGuards(AuthGuard, RequestSigningGuard)
 export class WorkersController {
   constructor(private readonly workersService: WorkersService) {}
 


### PR DESCRIPTION
## Summary

Adds request signing and replay-protection scaffolding on top of the API-key RBAC foundation.

## Added

- request signature header constants
- HMAC-SHA256 signature service
- in-memory nonce store
- request signing guard
- signed route decorator
- worker controller wired with request signing guard
- request signing docs
- signature service tests

## Notes

This is the first request-signing pass. The nonce store is intentionally in-memory so the contract can be validated before wiring Redis for multi-instance deployment. The next hardening PR should enforce signed routes on specific worker/vendor/admin write operations and add Redis-backed nonce persistence.

Progresses #37.