### PR TITLE
Enforce signed job writes and add Redis nonce store

### DIFF
--- a/services/orchestrator/docs/request-signing.md
+++ b/services/orchestrator/docs/request-signing.md
@@ -32,15 +32,22 @@ Requests are accepted only when the timestamp is within five minutes of server t
 
 Each nonce can be used once per role/API-key scope during the replay window.
 
+## Nonce store modes
+
+`NONCE_STORE=memory` uses the local in-process nonce store and is appropriate for local development or single-instance test environments.
+
+`NONCE_STORE=redis` uses Redis so replay protection works across multiple orchestrator instances. `REDIS_URL` is required in this mode.
+
 ## Current implementation
 
-This PR adds:
+This implementation includes:
 
 - signature header constants
 - signature service
-- nonce store
+- memory nonce store
+- Redis nonce store mode
 - request signing guard
 - route decorator for signed endpoints
 - unit tests for HMAC signing
 
-The nonce store is in-memory for the first pass. It should be replaced with Redis before multi-instance production deployment.
+Use Redis before multi-instance production deployment.

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -27,6 +27,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "helmet": "^8.0.0",
+    "ioredis": "^5.4.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.24.1"
@@ -53,19 +54,11 @@
     "typescript": "^5.7.2"
   },
   "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
+    "moduleFileExtensions": ["js", "json", "ts"],
     "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "src/**/*.(t|j)s"
-    ],
+    "transform": { "^.+\\.(t|j)s$": "ts-jest" },
+    "collectCoverageFrom": ["src/**/*.(t|j)s"],
     "coverageDirectory": "coverage",
     "testEnvironment": "node"
   }

--- a/services/orchestrator/src/auth/nonce.store.spec.ts
+++ b/services/orchestrator/src/auth/nonce.store.spec.ts
@@ -1,0 +1,17 @@
+import { ConfigService } from '@nestjs/config';
+
+import { NonceStore } from './nonce.store';
+
+describe('NonceStore', () => {
+  it('accepts a nonce once per scope', async () => {
+    const config = {
+      get: (key: string) => (key === 'NONCE_STORE' ? 'memory' : undefined),
+    } as ConfigService<any, true>;
+
+    const store = new NonceStore(config);
+
+    await expect(store.remember('worker:key', 'nonce-1', 300)).resolves.toBe(true);
+    await expect(store.remember('worker:key', 'nonce-1', 300)).resolves.toBe(false);
+    await store.onModuleDestroy();
+  });
+});

--- a/services/orchestrator/src/auth/nonce.store.ts
+++ b/services/orchestrator/src/auth/nonce.store.ts
@@ -1,23 +1,48 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+import { EnvConfig } from '../common/config/env.schema';
 
 interface NonceEntry {
   expiresAt: number;
 }
 
 @Injectable()
-export class NonceStore {
+export class NonceStore implements OnModuleDestroy {
   private readonly nonces = new Map<string, NonceEntry>();
+  private readonly redis?: Redis;
 
-  remember(scope: string, nonce: string, ttlSeconds: number): boolean {
+  constructor(private readonly config: ConfigService<EnvConfig, true>) {
+    if (this.config.get('NONCE_STORE', { infer: true }) === 'redis') {
+      this.redis = new Redis(this.config.get('REDIS_URL', { infer: true }));
+    }
+  }
+
+  async remember(scope: string, nonce: string, ttlSeconds: number): Promise<boolean> {
+    const key = this.key(scope, nonce);
+
+    if (this.redis) {
+      const result = await this.redis.set(key, '1', 'EX', ttlSeconds, 'NX');
+      return result === 'OK';
+    }
+
     this.prune();
 
-    const key = `${scope}:${nonce}`;
     if (this.nonces.has(key)) {
       return false;
     }
 
     this.nonces.set(key, { expiresAt: Date.now() + ttlSeconds * 1000 });
     return true;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis?.quit();
+  }
+
+  private key(scope: string, nonce: string): string {
+    return `hnh:nonce:${scope}:${nonce}`;
   }
 
   private prune(): void {

--- a/services/orchestrator/src/auth/request-signing.guard.ts
+++ b/services/orchestrator/src/auth/request-signing.guard.ts
@@ -19,7 +19,7 @@ export class RequestSigningGuard implements CanActivate {
     private readonly signatures: SignatureService,
   ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const requiresSignature = this.reflector.getAllAndOverride<boolean>(signedRouteMetadataKey, [
       context.getHandler(),
       context.getClass(),
@@ -42,7 +42,9 @@ export class RequestSigningGuard implements CanActivate {
 
     this.assertFreshTimestamp(timestamp);
 
-    if (!this.nonceStore.remember(`${role}:${apiKey}`, nonce, maxSignatureAgeSeconds)) {
+    const nonceAccepted = await this.nonceStore.remember(`${role}:${apiKey}`, nonce, maxSignatureAgeSeconds);
+
+    if (!nonceAccepted) {
       throw new UnauthorizedException('Replay detected for HashNHedge signed request');
     }
 

--- a/services/orchestrator/src/common/config/env.schema.ts
+++ b/services/orchestrator/src/common/config/env.schema.ts
@@ -10,6 +10,8 @@ export const envSchema = z.object({
   ALLOWED_ORIGINS: z.string().default('http://localhost:3000'),
   JWT_SECRET: z.string().min(24, 'JWT_SECRET must be at least 24 characters'),
   DATABASE_URL: z.string().url().or(z.string().startsWith('postgresql://')),
+  REDIS_URL: z.string().url().optional(),
+  NONCE_STORE: z.enum(['memory', 'redis']).default('memory'),
   ADMIN_API_KEY: secretSchema.default('local-admin-api-key-change-me'),
   WORKER_API_KEY: secretSchema.default('local-worker-api-key-change-me'),
   VENDOR_API_KEY: secretSchema.default('local-vendor-api-key-change-me'),
@@ -26,6 +28,10 @@ export function validateEnv(config: Record<string, unknown>): EnvConfig {
       .join('; ');
 
     throw new Error(`Invalid orchestrator environment: ${errors}`);
+  }
+
+  if (parsed.data.NONCE_STORE === 'redis' && !parsed.data.REDIS_URL) {
+    throw new Error('Invalid orchestrator environment: REDIS_URL is required when NONCE_STORE=redis');
   }
 
   return parsed.data;

--- a/services/orchestrator/src/jobs/jobs.controller.ts
+++ b/services/orchestrator/src/jobs/jobs.controller.ts
@@ -2,8 +2,10 @@ import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 import { AuthGuard } from '../auth/auth.guard';
+import { RequestSigningGuard } from '../auth/request-signing.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../auth/roles';
+import { SignedRoute } from '../auth/signed.decorator';
 import { CreateJobDto } from './dto/create-job.dto';
 import { LeaseJobDto } from './dto/lease-job.dto';
 import { JobRecord, JobsService, RecoverySummary } from './jobs.service';
@@ -11,11 +13,12 @@ import { JobRecord, JobsService, RecoverySummary } from './jobs.service';
 @ApiTags('jobs')
 @ApiSecurity('x-hnh-api-key')
 @Controller('jobs')
-@UseGuards(AuthGuard)
+@UseGuards(AuthGuard, RequestSigningGuard)
 export class JobsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Post()
+  @SignedRoute()
   @Roles(Role.Vendor, Role.Admin)
   @ApiCreatedResponse({ description: 'Job queued' })
   createJob(@Body() dto: CreateJobDto): Promise<JobRecord> {
@@ -37,6 +40,7 @@ export class JobsController {
   }
 
   @Post('lease-next')
+  @SignedRoute()
   @Roles(Role.Worker, Role.Admin)
   @ApiOkResponse({ description: 'Next queued job leased to worker' })
   leaseNextJob(@Body() dto: LeaseJobDto): Promise<JobRecord> {
@@ -44,6 +48,7 @@ export class JobsController {
   }
 
   @Post('recover-expired-leases')
+  @SignedRoute()
   @Roles(Role.Admin)
   @ApiOkResponse({ description: 'Expired leases processed' })
   recoverExpiredLeases(): Promise<RecoverySummary> {
@@ -51,6 +56,7 @@ export class JobsController {
   }
 
   @Post(':jobId/running')
+  @SignedRoute()
   @Roles(Role.Worker, Role.Admin)
   @ApiOkResponse({ description: 'Job marked running' })
   markRunning(@Param('jobId') jobId: string): Promise<JobRecord> {

--- a/services/orchestrator/test/workers-jobs.e2e-spec.ts
+++ b/services/orchestrator/test/workers-jobs.e2e-spec.ts
@@ -1,14 +1,30 @@
+import { createHmac } from 'crypto';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 
 import { AppModule } from '../src/app.module';
 import { apiKeyHeaderName, roleHeaderName, Role } from '../src/auth/roles';
+import { nonceHeaderName, signatureHeaderName, timestampHeaderName } from '../src/auth/signature.headers';
 import { PrismaService } from '../src/database/prisma.service';
 
 const adminKey = 'test-admin-api-key-that-is-long';
 const workerKey = 'test-worker-api-key-that-is-long';
 const vendorKey = 'test-vendor-api-key-that-is-long';
+
+function signedHeaders(method: string, path: string, role: Role, key: string, body: unknown, nonce: string) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const payload = [method, path, timestamp, nonce, JSON.stringify(body ?? {})].join('|');
+  const signature = createHmac('sha256', key).update(payload).digest('hex');
+
+  return {
+    [roleHeaderName]: role,
+    [apiKeyHeaderName]: key,
+    [timestampHeaderName]: timestamp,
+    [nonceHeaderName]: nonce,
+    [signatureHeaderName]: signature,
+  };
+}
 
 function createMockPrisma() {
   const workers = new Map<string, any>();
@@ -85,32 +101,33 @@ describe('Worker and job loop', () => {
   });
 
   it('registers a worker, queues a job, and leases the job', async () => {
+    const workerBody = {
+      workerName: 'worker-rig-001',
+      walletAddress: 'GCKbEgD4VSLtkwt57At7pWscaxaQ2gBZtTQE2hqr3Yrc',
+      capabilities: ['mining', 'ai-inference'],
+      gpuCount: 2,
+    };
+
     await request(app.getHttpServer())
       .post('/workers')
-      .set(roleHeaderName, Role.Worker)
-      .set(apiKeyHeaderName, workerKey)
-      .send({
-        workerName: 'worker-rig-001',
-        walletAddress: 'GCKbEgD4VSLtkwt57At7pWscaxaQ2gBZtTQE2hqr3Yrc',
-        capabilities: ['mining', 'ai-inference'],
-        gpuCount: 2,
-      })
+      .set(signedHeaders('POST', '/workers', Role.Worker, workerKey, workerBody, 'nonce-worker-register'))
+      .send(workerBody)
       .expect(201);
 
+    const jobBody = { jobType: 'ai-inference', description: 'Inference batch' };
     const jobResponse = await request(app.getHttpServer())
       .post('/jobs')
-      .set(roleHeaderName, Role.Vendor)
-      .set(apiKeyHeaderName, vendorKey)
-      .send({ jobType: 'ai-inference', description: 'Inference batch' })
+      .set(signedHeaders('POST', '/jobs', Role.Vendor, vendorKey, jobBody, 'nonce-job-create'))
+      .send(jobBody)
       .expect(201);
 
     expect(jobResponse.body.status).toBe('QUEUED');
 
+    const leaseBody = { workerId: 'worker-rig-001' };
     const leaseResponse = await request(app.getHttpServer())
       .post('/jobs/lease-next')
-      .set(roleHeaderName, Role.Worker)
-      .set(apiKeyHeaderName, workerKey)
-      .send({ workerId: 'worker-rig-001' })
+      .set(signedHeaders('POST', '/jobs/lease-next', Role.Worker, workerKey, leaseBody, 'nonce-job-lease'))
+      .send(leaseBody)
       .expect(201);
 
     expect(leaseResponse.body.status).toBe('ASSIGNED');


### PR DESCRIPTION
## Summary

Hardens the orchestrator request-signing layer by adding Redis-backed nonce storage and enforcing signatures on sensitive job write operations.

## Added

- `ioredis` dependency
- `NONCE_STORE` and `REDIS_URL` config validation
- Redis-backed nonce store mode for multi-instance replay protection
- async nonce replay checks in the request signing guard
- signed job write routes:
  - job creation
  - job leasing
  - lease recovery
  - mark running
- signed e2e request helper for job/worker flow
- nonce store replay unit test
- updated request signing docs for memory vs Redis modes

## Notes

The worker controller already has the signing guard mounted. This PR enforces signed job writes directly and makes the nonce backend production-capable via Redis. The next hardening PR should finish route-level signing coverage for worker writes and add a Redis-backed integration test once CI has Redis available.

Progresses #37.