### PR TITLE
Finish worker write signing coverage

### DIFF
--- a/services/orchestrator/docs/redis-ci.md
+++ b/services/orchestrator/docs/redis-ci.md
@@ -1,0 +1,35 @@
+# Redis CI Integration Plan
+
+## Goal
+
+Validate HashNHedge request replay protection against a real Redis instance in CI.
+
+## Required CI service
+
+Use a Redis service container for orchestrator integration tests.
+
+```yaml
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - 6379:6379
+```
+
+## Environment
+
+```bash
+NONCE_STORE=redis
+REDIS_URL=redis://localhost:6379
+```
+
+## Test coverage to add
+
+- first signed request with a nonce is accepted
+- repeated request with the same nonce is rejected
+- same nonce under a different role/API-key scope is accepted
+- expired nonce can be reused only after the replay window expires
+
+## Production note
+
+Redis-backed nonce storage is required before running more than one orchestrator instance. The in-memory nonce store is acceptable only for local development and single-instance smoke tests.

--- a/services/orchestrator/src/workers/workers.controller.ts
+++ b/services/orchestrator/src/workers/workers.controller.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from '../auth/auth.guard';
 import { RequestSigningGuard } from '../auth/request-signing.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../auth/roles';
+import { SignedRoute } from '../auth/signed.decorator';
 import { HeartbeatDto } from './dto/heartbeat.dto';
 import { RegisterWorkerDto } from './dto/register-worker.dto';
 import { WorkerRecord, WorkersService } from './workers.service';
@@ -17,6 +18,7 @@ export class WorkersController {
   constructor(private readonly workersService: WorkersService) {}
 
   @Post()
+  @SignedRoute()
   @Roles(Role.Worker, Role.Admin)
   @ApiCreatedResponse({ description: 'Worker registered or refreshed' })
   registerWorker(@Body() dto: RegisterWorkerDto): Promise<WorkerRecord> {
@@ -38,6 +40,7 @@ export class WorkersController {
   }
 
   @Post(':workerId/heartbeat')
+  @SignedRoute()
   @Roles(Role.Worker, Role.Admin)
   @ApiOkResponse({ description: 'Worker heartbeat accepted' })
   heartbeat(@Param('workerId') workerId: string, @Body() dto: HeartbeatDto): Promise<WorkerRecord> {


### PR DESCRIPTION
## Summary

Finishes the route-level signing coverage for worker write operations and documents Redis CI validation.

## Added

- `@SignedRoute()` on worker registration
- `@SignedRoute()` on worker heartbeat
- Redis CI integration plan for replay-protection tests

## Notes

This closes the remaining gap from PR #44 where the worker controller had the signing guard mounted but write routes were not explicitly marked as signed routes. The next PR should add an actual GitHub Actions workflow with Redis/Postgres services once the repo CI shape is settled.

Progresses #37.