### PR TITLE
Add orchestrator audit logging and redaction

### DIFF
--- a/services/orchestrator/docs/audit-logging.md
+++ b/services/orchestrator/docs/audit-logging.md
@@ -1,0 +1,44 @@
+# Audit Logging and Redaction
+
+The orchestrator emits structured audit events for write operations.
+
+## Audited operations
+
+The global audit interceptor records non-read HTTP operations:
+
+- worker registration
+- worker heartbeat
+- job creation
+- job leasing
+- lease recovery
+- job lifecycle transitions
+
+## Event fields
+
+Audit events include:
+
+- `action`
+- `actorRole`
+- `outcome`
+- `requestId`
+- `ip`
+- `userAgent`
+- `metadata`
+- `timestamp`
+
+## Redaction
+
+The audit logger redacts sensitive fields before logging, including:
+
+- authorization headers
+- cookies
+- API keys
+- signatures
+- passwords
+- tokens
+- JWT values
+- secrets
+
+## Production notes
+
+Logs should be shipped to a centralized system such as Loki, Datadog, or a SIEM. Alert rules should watch for repeated denied requests, replay attempts, signature failures, and high-risk admin actions.

--- a/services/orchestrator/src/common/audit/audit-logger.service.ts
+++ b/services/orchestrator/src/common/audit/audit-logger.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { redactObject } from '../redaction/redactor';
+
+export interface AuditEvent {
+  action: string;
+  actorRole?: string;
+  actorId?: string;
+  targetType?: string;
+  targetId?: string;
+  outcome: 'success' | 'failure' | 'denied';
+  requestId?: string;
+  ip?: string;
+  userAgent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Injectable()
+export class AuditLoggerService {
+  private readonly logger = new Logger('Audit');
+
+  log(event: AuditEvent): void {
+    const payload = redactObject({
+      ...event,
+      timestamp: new Date().toISOString(),
+    });
+
+    this.logger.log(JSON.stringify(payload));
+  }
+}

--- a/services/orchestrator/src/common/audit/audit.interceptor.ts
+++ b/services/orchestrator/src/common/audit/audit.interceptor.ts
@@ -1,0 +1,61 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Request } from 'express';
+import { Observable, catchError, tap, throwError } from 'rxjs';
+
+import { apiKeyHeaderName, roleHeaderName } from '../../auth/roles';
+import { AuditLoggerService } from './audit-logger.service';
+
+@Injectable()
+export class AuditInterceptor implements NestInterceptor {
+  constructor(private readonly audit: AuditLoggerService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const startedAt = Date.now();
+    const action = `${request.method} ${request.route?.path ?? request.url}`;
+    const role = request.header(roleHeaderName);
+    const requestId = request.header('x-request-id');
+
+    return next.handle().pipe(
+      tap(() => {
+        if (this.shouldAudit(request.method)) {
+          this.audit.log({
+            action,
+            actorRole: role,
+            outcome: 'success',
+            requestId,
+            ip: request.ip,
+            userAgent: request.header('user-agent'),
+            metadata: {
+              durationMs: Date.now() - startedAt,
+              hasApiKey: Boolean(request.header(apiKeyHeaderName)),
+            },
+          });
+        }
+      }),
+      catchError((error: Error) => {
+        if (this.shouldAudit(request.method)) {
+          this.audit.log({
+            action,
+            actorRole: role,
+            outcome: 'failure',
+            requestId,
+            ip: request.ip,
+            userAgent: request.header('user-agent'),
+            metadata: {
+              durationMs: Date.now() - startedAt,
+              errorName: error.name,
+              errorMessage: error.message,
+            },
+          });
+        }
+
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  private shouldAudit(method: string): boolean {
+    return !['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase());
+  }
+}

--- a/services/orchestrator/src/common/audit/audit.module.ts
+++ b/services/orchestrator/src/common/audit/audit.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+
+import { AuditLoggerService } from './audit-logger.service';
+
+@Global()
+@Module({
+  providers: [AuditLoggerService],
+  exports: [AuditLoggerService],
+})
+export class AuditModule {}

--- a/services/orchestrator/src/common/redaction/redactor.spec.ts
+++ b/services/orchestrator/src/common/redaction/redactor.spec.ts
@@ -1,0 +1,23 @@
+import { redactObject } from './redactor';
+
+describe('redactObject', () => {
+  it('redacts sensitive fields recursively', () => {
+    expect(
+      redactObject({
+        authorization: 'Bearer secret',
+        safe: 'visible',
+        nested: {
+          token: 'secret-token',
+          value: 42,
+        },
+      }),
+    ).toEqual({
+      authorization: '[REDACTED]',
+      safe: 'visible',
+      nested: {
+        token: '[REDACTED]',
+        value: 42,
+      },
+    });
+  });
+});

--- a/services/orchestrator/src/common/redaction/redactor.ts
+++ b/services/orchestrator/src/common/redaction/redactor.ts
@@ -1,0 +1,38 @@
+const sensitiveKeys = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-hnh-api-key',
+  'x-hnh-signature',
+  'apiKey',
+  'api_key',
+  'password',
+  'secret',
+  'token',
+  'jwt',
+  'signature',
+]);
+
+export function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
+  }
+
+  if (value && typeof value === 'object') {
+    return redactObject(value as Record<string, unknown>);
+  }
+
+  return value;
+}
+
+export function redactObject(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => {
+      if (sensitiveKeys.has(key) || sensitiveKeys.has(key.toLowerCase())) {
+        return [key, '[REDACTED]'];
+      }
+
+      return [key, redactValue(value)];
+    }),
+  );
+}

--- a/services/orchestrator/src/main.ts
+++ b/services/orchestrator/src/main.ts
@@ -5,6 +5,8 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 
 import { AppModule } from './app.module';
+import { AuditInterceptor } from './common/audit/audit.interceptor';
+import { AuditLoggerService } from './common/audit/audit-logger.service';
 import { EnvConfig } from './common/config/env.schema';
 
 async function bootstrap(): Promise<void> {
@@ -13,12 +15,9 @@ async function bootstrap(): Promise<void> {
   const config = app.get(ConfigService<EnvConfig, true>);
 
   app.use(helmet());
+  app.useGlobalInterceptors(new AuditInterceptor(app.get(AuditLoggerService)));
   app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
+    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
   );
 
   const allowedOrigins = config
@@ -33,7 +32,6 @@ async function bootstrap(): Promise<void> {
         callback(null, true);
         return;
       }
-
       callback(new Error('Origin not allowed by HashNHedge orchestrator CORS policy'));
     },
     credentials: true,


### PR DESCRIPTION
## Summary

Adds structured audit logging and sensitive-data redaction to the NestJS orchestrator.

## Added

- redaction utility for sensitive fields
- structured audit logger service
- global audit interceptor for write operations
- audit logging docs
- redaction unit test

## Notes

The audit interceptor is registered globally in `main.ts` and records non-read operations with request metadata, duration, actor role, outcome, and redacted metadata. I added the audit module file, but the connector blocked the `app.module.ts` update, so `main.ts` imports the audit service directly and this may need a follow-up compile check/manual adjustment if Nest cannot resolve the provider.

Next build step: add circuit breakers for high-risk API operations.

Progresses #37.