### PR TITLE
Add orchestrator circuit breakers for high-risk actions

### DIFF
--- a/services/orchestrator/docs/circuit-breakers.md
+++ b/services/orchestrator/docs/circuit-breakers.md
@@ -1,0 +1,37 @@
+# Circuit Breakers
+
+Circuit breakers allow operators to pause high-risk orchestrator actions during incidents without taking the whole API offline.
+
+## Breakers
+
+- `worker-registration`
+- `job-creation`
+- `job-leasing`
+- `lease-recovery`
+- `payouts`
+- `admin-actions`
+
+## Protected operations
+
+Initial protected API operations:
+
+- worker registration
+- job creation
+- job leasing
+- lease recovery
+- marking jobs running
+
+## Admin controls
+
+The admin controller exposes circuit breaker state management:
+
+- `GET /admin/circuit-breakers`
+- `PUT /admin/circuit-breakers/:name`
+
+Admin writes must be signed and authenticated.
+
+## Production notes
+
+The first implementation uses an in-process store. Before multi-instance production deployment, move breaker state to Redis/PostgreSQL so all orchestrator instances share the same safety state.
+
+Circuit breaker state changes should also be mirrored to alerting and audit systems.

--- a/services/orchestrator/src/admin/admin.controller.ts
+++ b/services/orchestrator/src/admin/admin.controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Get, Param, Put, UseGuards } from '@nestjs/common';
+import { ApiOkResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+
+import { AuthGuard } from '../auth/auth.guard';
+import { RequestSigningGuard } from '../auth/request-signing.guard';
+import { Role } from '../auth/roles';
+import { Roles } from '../auth/roles.decorator';
+import { SignedRoute } from '../auth/signed.decorator';
+import { CircuitBreakerName, CircuitBreakerState, CircuitBreakerStore } from '../common/safety/circuit-breaker.store';
+import { breakerNames, UpdateBreakerDto } from './dto/update-breaker.dto';
+
+@ApiTags('admin')
+@ApiSecurity('x-hnh-api-key')
+@Controller('admin')
+@UseGuards(AuthGuard, RequestSigningGuard)
+export class AdminController {
+  constructor(private readonly breakers: CircuitBreakerStore) {}
+
+  @Get('circuit-breakers')
+  @Roles(Role.Admin)
+  @ApiOkResponse({ description: 'Circuit breaker states' })
+  listBreakers(): CircuitBreakerState[] {
+    return this.breakers.list();
+  }
+
+  @Put('circuit-breakers/:name')
+  @SignedRoute()
+  @Roles(Role.Admin)
+  @ApiOkResponse({ description: 'Circuit breaker state updated' })
+  updateBreaker(@Param('name') name: CircuitBreakerName, @Body() dto: UpdateBreakerDto): CircuitBreakerState {
+    if (!breakerNames.includes(name)) {
+      throw new Error(`Unknown circuit breaker: ${name}`);
+    }
+
+    if (dto.state === 'open') {
+      return this.breakers.open(name, dto.reason ?? 'manual_admin_action', dto.actorId);
+    }
+
+    return this.breakers.close(name);
+  }
+}

--- a/services/orchestrator/src/admin/admin.module.ts
+++ b/services/orchestrator/src/admin/admin.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { AdminController } from './admin.controller';
+
+@Module({
+  controllers: [AdminController]
+})
+export class AdminModule {}

--- a/services/orchestrator/src/admin/dto/update-breaker.dto.ts
+++ b/services/orchestrator/src/admin/dto/update-breaker.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString, MinLength } from 'class-validator';
+
+import { CircuitBreakerName } from '../../common/safety/circuit-breaker.store';
+
+export class UpdateBreakerDto {
+  @ApiProperty({ enum: ['open', 'closed'] })
+  @IsIn(['open', 'closed'])
+  state!: 'open' | 'closed';
+
+  @ApiPropertyOptional({ example: 'suspected payout anomaly' })
+  @IsOptional()
+  @IsString()
+  @MinLength(3)
+  reason?: string;
+
+  @ApiPropertyOptional({ example: 'admin@example.com' })
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+}
+
+export const breakerNames: CircuitBreakerName[] = [
+  'worker-registration',
+  'job-creation',
+  'job-leasing',
+  'lease-recovery',
+  'payouts',
+  'admin-actions',
+];

--- a/services/orchestrator/src/common/safety/circuit-breaker.decorator.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+
+import { CircuitBreakerName } from './circuit-breaker.store';
+
+export const circuitBreakerMetadataKey = 'hnh_circuit_breaker';
+
+export const CircuitBreaker = (name: CircuitBreakerName) => SetMetadata(circuitBreakerMetadataKey, name);

--- a/services/orchestrator/src/common/safety/circuit-breaker.guard.spec.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.guard.spec.ts
@@ -1,0 +1,31 @@
+import { ExecutionContext, ServiceUnavailableException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { CircuitBreakerGuard } from './circuit-breaker.guard';
+import { CircuitBreakerStore } from './circuit-breaker.store';
+
+function createContext(): ExecutionContext {
+  return {
+    getHandler: () => jest.fn(),
+    getClass: () => class TestController {},
+  } as unknown as ExecutionContext;
+}
+
+describe('CircuitBreakerGuard', () => {
+  it('allows traffic when breaker is closed', () => {
+    const reflector = { getAllAndOverride: () => 'job-creation' } as unknown as Reflector;
+    const store = new CircuitBreakerStore();
+    const guard = new CircuitBreakerGuard(reflector, store);
+
+    expect(guard.canActivate(createContext())).toBe(true);
+  });
+
+  it('blocks traffic when breaker is open', () => {
+    const reflector = { getAllAndOverride: () => 'job-creation' } as unknown as Reflector;
+    const store = new CircuitBreakerStore();
+    store.open('job-creation', 'test');
+    const guard = new CircuitBreakerGuard(reflector, store);
+
+    expect(() => guard.canActivate(createContext())).toThrow(ServiceUnavailableException);
+  });
+});

--- a/services/orchestrator/src/common/safety/circuit-breaker.guard.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.guard.ts
@@ -1,0 +1,35 @@
+import { CanActivate, ExecutionContext, Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { circuitBreakerMetadataKey } from './circuit-breaker.decorator';
+import { CircuitBreakerName, CircuitBreakerStore } from './circuit-breaker.store';
+
+@Injectable()
+export class CircuitBreakerGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly store: CircuitBreakerStore,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const breakerName = this.reflector.getAllAndOverride<CircuitBreakerName>(circuitBreakerMetadataKey, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!breakerName) {
+      return true;
+    }
+
+    const state = this.store.get(breakerName);
+
+    if (state.open) {
+      throw new ServiceUnavailableException({
+        message: `HashNHedge circuit breaker is open: ${breakerName}`,
+        breaker: state,
+      });
+    }
+
+    return true;
+  }
+}

--- a/services/orchestrator/src/common/safety/circuit-breaker.store.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.store.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+
+export type CircuitBreakerName =
+  | 'worker-registration'
+  | 'job-creation'
+  | 'job-leasing'
+  | 'lease-recovery'
+  | 'payouts'
+  | 'admin-actions';
+
+export interface CircuitBreakerState {
+  name: CircuitBreakerName;
+  open: boolean;
+  reason?: string;
+  openedAt?: string;
+  openedBy?: string;
+}
+
+@Injectable()
+export class CircuitBreakerStore {
+  private readonly states = new Map<CircuitBreakerName, CircuitBreakerState>();
+
+  constructor() {
+    for (const name of this.knownBreakers()) {
+      this.states.set(name, { name, open: false });
+    }
+  }
+
+  list(): CircuitBreakerState[] {
+    return Array.from(this.states.values());
+  }
+
+  get(name: CircuitBreakerName): CircuitBreakerState {
+    return this.states.get(name) ?? { name, open: false };
+  }
+
+  open(name: CircuitBreakerName, reason: string, openedBy?: string): CircuitBreakerState {
+    const state: CircuitBreakerState = {
+      name,
+      open: true,
+      reason,
+      openedBy,
+      openedAt: new Date().toISOString(),
+    };
+
+    this.states.set(name, state);
+    return state;
+  }
+
+  close(name: CircuitBreakerName): CircuitBreakerState {
+    const state: CircuitBreakerState = { name, open: false };
+    this.states.set(name, state);
+    return state;
+  }
+
+  private knownBreakers(): CircuitBreakerName[] {
+    return ['worker-registration', 'job-creation', 'job-leasing', 'lease-recovery', 'payouts', 'admin-actions'];
+  }
+}

--- a/services/orchestrator/src/common/safety/safety.module.ts
+++ b/services/orchestrator/src/common/safety/safety.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { CircuitBreakerGuard } from './circuit-breaker.guard';
+import { CircuitBreakerStore } from './circuit-breaker.store';
+
+@Module({
+  providers: [CircuitBreakerStore, CircuitBreakerGuard],
+  exports: [CircuitBreakerStore, CircuitBreakerGuard],
+})
+export class SafetyModule {}

--- a/services/orchestrator/src/jobs/jobs.controller.ts
+++ b/services/orchestrator/src/jobs/jobs.controller.ts
@@ -6,6 +6,8 @@ import { RequestSigningGuard } from '../auth/request-signing.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../auth/roles';
 import { SignedRoute } from '../auth/signed.decorator';
+import { CircuitBreaker } from '../common/safety/circuit-breaker.decorator';
+import { CircuitBreakerGuard } from '../common/safety/circuit-breaker.guard';
 import { CreateJobDto } from './dto/create-job.dto';
 import { LeaseJobDto } from './dto/lease-job.dto';
 import { JobRecord, JobsService, RecoverySummary } from './jobs.service';
@@ -13,12 +15,13 @@ import { JobRecord, JobsService, RecoverySummary } from './jobs.service';
 @ApiTags('jobs')
 @ApiSecurity('x-hnh-api-key')
 @Controller('jobs')
-@UseGuards(AuthGuard, RequestSigningGuard)
+@UseGuards(AuthGuard, RequestSigningGuard, CircuitBreakerGuard)
 export class JobsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Post()
   @SignedRoute()
+  @CircuitBreaker('job-creation')
   @Roles(Role.Vendor, Role.Admin)
   @ApiCreatedResponse({ description: 'Job queued' })
   createJob(@Body() dto: CreateJobDto): Promise<JobRecord> {
@@ -41,6 +44,7 @@ export class JobsController {
 
   @Post('lease-next')
   @SignedRoute()
+  @CircuitBreaker('job-leasing')
   @Roles(Role.Worker, Role.Admin)
   @ApiOkResponse({ description: 'Next queued job leased to worker' })
   leaseNextJob(@Body() dto: LeaseJobDto): Promise<JobRecord> {
@@ -49,6 +53,7 @@ export class JobsController {
 
   @Post('recover-expired-leases')
   @SignedRoute()
+  @CircuitBreaker('lease-recovery')
   @Roles(Role.Admin)
   @ApiOkResponse({ description: 'Expired leases processed' })
   recoverExpiredLeases(): Promise<RecoverySummary> {
@@ -57,6 +62,7 @@ export class JobsController {
 
   @Post(':jobId/running')
   @SignedRoute()
+  @CircuitBreaker('job-leasing')
   @Roles(Role.Worker, Role.Admin)
   @ApiOkResponse({ description: 'Job marked running' })
   markRunning(@Param('jobId') jobId: string): Promise<JobRecord> {

--- a/services/orchestrator/src/workers/workers.controller.ts
+++ b/services/orchestrator/src/workers/workers.controller.ts
@@ -6,6 +6,8 @@ import { RequestSigningGuard } from '../auth/request-signing.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '../auth/roles';
 import { SignedRoute } from '../auth/signed.decorator';
+import { CircuitBreaker } from '../common/safety/circuit-breaker.decorator';
+import { CircuitBreakerGuard } from '../common/safety/circuit-breaker.guard';
 import { HeartbeatDto } from './dto/heartbeat.dto';
 import { RegisterWorkerDto } from './dto/register-worker.dto';
 import { WorkerRecord, WorkersService } from './workers.service';
@@ -13,12 +15,13 @@ import { WorkerRecord, WorkersService } from './workers.service';
 @ApiTags('workers')
 @ApiSecurity('x-hnh-api-key')
 @Controller('workers')
-@UseGuards(AuthGuard, RequestSigningGuard)
+@UseGuards(AuthGuard, RequestSigningGuard, CircuitBreakerGuard)
 export class WorkersController {
   constructor(private readonly workersService: WorkersService) {}
 
   @Post()
   @SignedRoute()
+  @CircuitBreaker('worker-registration')
   @Roles(Role.Worker, Role.Admin)
   @ApiCreatedResponse({ description: 'Worker registered or refreshed' })
   registerWorker(@Body() dto: RegisterWorkerDto): Promise<WorkerRecord> {


### PR DESCRIPTION
## Summary

Adds circuit breaker safety controls for high-risk orchestrator actions.

## Added

- circuit breaker state store
- `@CircuitBreaker(...)` decorator
- circuit breaker guard
- safety module
- admin circuit breaker controller and DTO
- job write breakers for job creation, leasing, lease recovery, and running transition
- worker registration breaker
- circuit breaker guard tests
- circuit breaker documentation

## Notes

This first pass uses an in-process breaker store. Before multi-instance production deployment, breaker state should move to Redis/PostgreSQL so all orchestrator instances share the same safety state.

The connector blocked one module import path while creating `AdminModule`, so this PR may need a small module-wiring pass after review/CI.

Progresses #37.