### PR TITLE
Add shared Redis-backed circuit breaker state

### DIFF
--- a/services/orchestrator/docs/circuit-breakers.md
+++ b/services/orchestrator/docs/circuit-breakers.md
@@ -30,8 +30,14 @@ The admin controller exposes circuit breaker state management:
 
 Admin writes must be signed and authenticated.
 
+## Store modes
+
+`BREAKER_STORE=memory` keeps breaker state in-process and is suitable for local development or single-instance testing.
+
+`BREAKER_STORE=redis` stores breaker state in Redis so all orchestrator instances share the same safety state. `REDIS_URL` is required in this mode.
+
 ## Production notes
 
-The first implementation uses an in-process store. Before multi-instance production deployment, move breaker state to Redis/PostgreSQL so all orchestrator instances share the same safety state.
+Use Redis-backed breaker state before running multiple orchestrator instances.
 
 Circuit breaker state changes should also be mirrored to alerting and audit systems.

--- a/services/orchestrator/src/admin/admin.controller.ts
+++ b/services/orchestrator/src/admin/admin.controller.ts
@@ -19,7 +19,7 @@ export class AdminController {
   @Get('circuit-breakers')
   @Roles(Role.Admin)
   @ApiOkResponse({ description: 'Circuit breaker states' })
-  listBreakers(): CircuitBreakerState[] {
+  listBreakers(): Promise<CircuitBreakerState[]> {
     return this.breakers.list();
   }
 
@@ -27,7 +27,7 @@ export class AdminController {
   @SignedRoute()
   @Roles(Role.Admin)
   @ApiOkResponse({ description: 'Circuit breaker state updated' })
-  updateBreaker(@Param('name') name: CircuitBreakerName, @Body() dto: UpdateBreakerDto): CircuitBreakerState {
+  updateBreaker(@Param('name') name: CircuitBreakerName, @Body() dto: UpdateBreakerDto): Promise<CircuitBreakerState> {
     if (!breakerNames.includes(name)) {
       throw new Error(`Unknown circuit breaker: ${name}`);
     }

--- a/services/orchestrator/src/common/config/env.schema.ts
+++ b/services/orchestrator/src/common/config/env.schema.ts
@@ -12,6 +12,7 @@ export const envSchema = z.object({
   DATABASE_URL: z.string().url().or(z.string().startsWith('postgresql://')),
   REDIS_URL: z.string().url().optional(),
   NONCE_STORE: z.enum(['memory', 'redis']).default('memory'),
+  BREAKER_STORE: z.enum(['memory', 'redis']).default('memory'),
   ADMIN_API_KEY: secretSchema.default('local-admin-api-key-change-me'),
   WORKER_API_KEY: secretSchema.default('local-worker-api-key-change-me'),
   VENDOR_API_KEY: secretSchema.default('local-vendor-api-key-change-me'),
@@ -32,6 +33,10 @@ export function validateEnv(config: Record<string, unknown>): EnvConfig {
 
   if (parsed.data.NONCE_STORE === 'redis' && !parsed.data.REDIS_URL) {
     throw new Error('Invalid orchestrator environment: REDIS_URL is required when NONCE_STORE=redis');
+  }
+
+  if (parsed.data.BREAKER_STORE === 'redis' && !parsed.data.REDIS_URL) {
+    throw new Error('Invalid orchestrator environment: REDIS_URL is required when BREAKER_STORE=redis');
   }
 
   return parsed.data;

--- a/services/orchestrator/src/common/safety/circuit-breaker.guard.spec.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.guard.spec.ts
@@ -1,4 +1,5 @@
 import { ExecutionContext, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 
 import { CircuitBreakerGuard } from './circuit-breaker.guard';
@@ -11,21 +12,27 @@ function createContext(): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
+function createConfig(): ConfigService<any, true> {
+  return {
+    get: (key: string) => (key === 'BREAKER_STORE' ? 'memory' : undefined),
+  } as ConfigService<any, true>;
+}
+
 describe('CircuitBreakerGuard', () => {
-  it('allows traffic when breaker is closed', () => {
+  it('allows traffic when breaker is closed', async () => {
     const reflector = { getAllAndOverride: () => 'job-creation' } as unknown as Reflector;
-    const store = new CircuitBreakerStore();
+    const store = new CircuitBreakerStore(createConfig());
     const guard = new CircuitBreakerGuard(reflector, store);
 
-    expect(guard.canActivate(createContext())).toBe(true);
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
   });
 
-  it('blocks traffic when breaker is open', () => {
+  it('blocks traffic when breaker is open', async () => {
     const reflector = { getAllAndOverride: () => 'job-creation' } as unknown as Reflector;
-    const store = new CircuitBreakerStore();
-    store.open('job-creation', 'test');
+    const store = new CircuitBreakerStore(createConfig());
+    await store.open('job-creation', 'test');
     const guard = new CircuitBreakerGuard(reflector, store);
 
-    expect(() => guard.canActivate(createContext())).toThrow(ServiceUnavailableException);
+    await expect(guard.canActivate(createContext())).rejects.toThrow(ServiceUnavailableException);
   });
 });

--- a/services/orchestrator/src/common/safety/circuit-breaker.guard.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.guard.ts
@@ -11,7 +11,7 @@ export class CircuitBreakerGuard implements CanActivate {
     private readonly store: CircuitBreakerStore,
   ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const breakerName = this.reflector.getAllAndOverride<CircuitBreakerName>(circuitBreakerMetadataKey, [
       context.getHandler(),
       context.getClass(),
@@ -21,7 +21,7 @@ export class CircuitBreakerGuard implements CanActivate {
       return true;
     }
 
-    const state = this.store.get(breakerName);
+    const state = await this.store.get(breakerName);
 
     if (state.open) {
       throw new ServiceUnavailableException({

--- a/services/orchestrator/src/common/safety/circuit-breaker.store.ts
+++ b/services/orchestrator/src/common/safety/circuit-breaker.store.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+import { EnvConfig } from '../config/env.schema';
 
 export type CircuitBreakerName =
   | 'worker-registration'
@@ -17,24 +21,39 @@ export interface CircuitBreakerState {
 }
 
 @Injectable()
-export class CircuitBreakerStore {
+export class CircuitBreakerStore implements OnModuleDestroy {
   private readonly states = new Map<CircuitBreakerName, CircuitBreakerState>();
+  private readonly redis?: Redis;
 
-  constructor() {
+  constructor(private readonly config: ConfigService<EnvConfig, true>) {
     for (const name of this.knownBreakers()) {
       this.states.set(name, { name, open: false });
     }
+
+    if (this.config.get('BREAKER_STORE', { infer: true }) === 'redis') {
+      this.redis = new Redis(this.config.get('REDIS_URL', { infer: true }));
+    }
   }
 
-  list(): CircuitBreakerState[] {
-    return Array.from(this.states.values());
+  async list(): Promise<CircuitBreakerState[]> {
+    if (!this.redis) {
+      return Array.from(this.states.values());
+    }
+
+    const states = await Promise.all(this.knownBreakers().map((name) => this.get(name)));
+    return states;
   }
 
-  get(name: CircuitBreakerName): CircuitBreakerState {
-    return this.states.get(name) ?? { name, open: false };
+  async get(name: CircuitBreakerName): Promise<CircuitBreakerState> {
+    if (!this.redis) {
+      return this.states.get(name) ?? { name, open: false };
+    }
+
+    const value = await this.redis.get(this.key(name));
+    return value ? (JSON.parse(value) as CircuitBreakerState) : { name, open: false };
   }
 
-  open(name: CircuitBreakerName, reason: string, openedBy?: string): CircuitBreakerState {
+  async open(name: CircuitBreakerName, reason: string, openedBy?: string): Promise<CircuitBreakerState> {
     const state: CircuitBreakerState = {
       name,
       open: true,
@@ -43,14 +62,33 @@ export class CircuitBreakerStore {
       openedAt: new Date().toISOString(),
     };
 
-    this.states.set(name, state);
+    if (this.redis) {
+      await this.redis.set(this.key(name), JSON.stringify(state));
+    } else {
+      this.states.set(name, state);
+    }
+
     return state;
   }
 
-  close(name: CircuitBreakerName): CircuitBreakerState {
+  async close(name: CircuitBreakerName): Promise<CircuitBreakerState> {
     const state: CircuitBreakerState = { name, open: false };
-    this.states.set(name, state);
+
+    if (this.redis) {
+      await this.redis.set(this.key(name), JSON.stringify(state));
+    } else {
+      this.states.set(name, state);
+    }
+
     return state;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis?.quit();
+  }
+
+  private key(name: CircuitBreakerName): string {
+    return `hnh:circuit-breaker:${name}`;
   }
 
   private knownBreakers(): CircuitBreakerName[] {


### PR DESCRIPTION
## Summary

Moves circuit breaker state toward production readiness by supporting shared Redis-backed storage across orchestrator instances.

## Added

- `BREAKER_STORE=memory|redis` configuration
- Redis-backed circuit breaker state storage
- validation requiring `REDIS_URL` when `BREAKER_STORE=redis`
- async circuit breaker guard checks
- async admin breaker endpoints
- updated circuit breaker tests
- circuit breaker docs for memory vs Redis modes

## Notes

This keeps memory mode for local development and test runs, while enabling Redis for multi-instance production deployments. The connector blocked the `.env.example` update, so the env docs are captured in `docs/circuit-breakers.md` for now.

Next build step: add metrics/observability baseline for workers, jobs, breakers, and API health.

Progresses #37.