### PR TITLE
Add orchestrator metrics and observability baseline

### DIFF
--- a/services/orchestrator/docs/grafana-dashboard.json
+++ b/services/orchestrator/docs/grafana-dashboard.json
@@ -1,0 +1,43 @@
+{
+  "title": "HashNHedge Orchestrator Baseline",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "API request rate",
+      "targets": [
+        { "expr": "sum by (route, status) (rate(hnh_http_requests_total[5m]))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "API p95 latency",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le, route) (rate(hnh_http_request_duration_seconds_bucket[5m])))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Active workers",
+      "targets": [
+        { "expr": "hnh_workers_active" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Queued jobs",
+      "targets": [
+        { "expr": "hnh_jobs_queued" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Open breakers",
+      "targets": [
+        { "expr": "hnh_circuit_breakers_open" }
+      ]
+    }
+  ]
+}

--- a/services/orchestrator/docs/metrics-followup.md
+++ b/services/orchestrator/docs/metrics-followup.md
@@ -1,0 +1,12 @@
+# Metrics follow-up wiring
+
+This branch adds the Prometheus metrics implementation and docs.
+
+Before merge or immediately after merge, verify:
+
+1. `MonitoringModule` is imported in `AppModule`.
+2. `MetricsService` can be resolved from the Nest container.
+3. `GET /metrics` returns Prometheus text format.
+4. The Grafana starter dashboard loads against the target Prometheus source.
+
+The connector blocked one `app.module.ts` update while creating this PR, so this note tracks the exact remaining wiring check.

--- a/services/orchestrator/docs/metrics.md
+++ b/services/orchestrator/docs/metrics.md
@@ -1,0 +1,42 @@
+# Orchestrator Metrics
+
+The orchestrator exposes Prometheus metrics at:
+
+```text
+GET /metrics
+```
+
+## Initial metrics
+
+- `hnh_http_requests_total`
+- `hnh_http_request_duration_seconds`
+- `hnh_workers_active`
+- `hnh_jobs_queued`
+- `hnh_circuit_breakers_open`
+- default Node.js process metrics prefixed with `hnh_`
+
+## Dashboard baseline
+
+Initial Grafana panels should include:
+
+- API request rate by route and status
+- API p95 and p99 latency
+- queued job count
+- active worker count
+- open circuit breaker count
+- process CPU and memory
+- Node event loop lag
+
+## Alert baseline
+
+Initial alerts should fire on:
+
+- sustained API 5xx rate
+- open circuit breaker count greater than zero
+- queued jobs above threshold
+- active workers dropping below threshold
+- process memory above threshold
+
+## Next steps
+
+Wire service-level gauges to database-backed worker/job/breaker counts and add OpenTelemetry traces for job lifecycle transitions.

--- a/services/orchestrator/docs/monitoring-module.md
+++ b/services/orchestrator/docs/monitoring-module.md
@@ -1,0 +1,16 @@
+# Monitoring module
+
+This module provides the first observability baseline for the HashNHedge orchestrator.
+
+## Files
+
+- `metrics.service.ts` defines Prometheus collectors.
+- `metrics.interceptor.ts` records HTTP request counts and duration.
+- `monitoring.controller.ts` exposes `GET /metrics`.
+- `monitoring.module.ts` groups the monitoring providers.
+
+## Required wiring
+
+Import `MonitoringModule` in `AppModule` and register `MetricsInterceptor` globally in `main.ts`.
+
+The interceptor wiring is included in this PR. The `AppModule` import may need a follow-up commit because the connector blocked that specific file update.

--- a/services/orchestrator/docs/observability-alerts.md
+++ b/services/orchestrator/docs/observability-alerts.md
@@ -1,0 +1,28 @@
+# Orchestrator Alert Baseline
+
+## Critical alerts
+
+- API 5xx rate above threshold for 5 minutes
+- any circuit breaker open for more than 1 minute
+- no active workers for 5 minutes
+- queued jobs above threshold for 10 minutes
+- process memory above threshold
+
+## Warning alerts
+
+- p95 latency above SLO
+- worker count drops by more than 50 percent in 10 minutes
+- job leasing failures increase
+- Redis connectivity degraded
+- PostgreSQL connectivity degraded
+
+## Follow-up
+
+Add OpenTelemetry traces for:
+
+- job creation
+- job leasing
+- worker heartbeat
+- lease recovery
+- proof submission
+- payout coordination

--- a/services/orchestrator/docs/prometheus-rules.md
+++ b/services/orchestrator/docs/prometheus-rules.md
@@ -1,0 +1,12 @@
+# Prometheus rules
+
+Starter alert rules are included in `docs/prometheus-rules.yml`.
+
+They cover:
+
+- open circuit breakers
+- elevated API 5xx rate
+- high queued job count
+- zero active workers
+
+Tune thresholds before production launch.

--- a/services/orchestrator/docs/prometheus-rules.yml
+++ b/services/orchestrator/docs/prometheus-rules.yml
@@ -1,0 +1,31 @@
+groups:
+  - name: hashnhedge-orchestrator
+    rules:
+      - alert: HNHOpenCircuitBreaker
+        expr: hnh_circuit_breakers_open > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: HashNHedge orchestrator circuit breaker open
+      - alert: HNHApiErrorRateHigh
+        expr: sum(rate(hnh_http_requests_total{status=~"5.."}[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: HashNHedge orchestrator API error rate is elevated
+      - alert: HNHQueuedJobsHigh
+        expr: hnh_jobs_queued > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: HashNHedge orchestrator job queue is elevated
+      - alert: HNHNoActiveWorkers
+        expr: hnh_workers_active == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: HashNHedge has no active workers

--- a/services/orchestrator/package.json
+++ b/services/orchestrator/package.json
@@ -28,6 +28,7 @@
     "class-validator": "^0.14.1",
     "helmet": "^8.0.0",
     "ioredis": "^5.4.2",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.24.1"

--- a/services/orchestrator/src/main.ts
+++ b/services/orchestrator/src/main.ts
@@ -8,6 +8,8 @@ import { AppModule } from './app.module';
 import { AuditInterceptor } from './common/audit/audit.interceptor';
 import { AuditLoggerService } from './common/audit/audit-logger.service';
 import { EnvConfig } from './common/config/env.schema';
+import { MetricsInterceptor } from './monitoring/metrics.interceptor';
+import { MetricsService } from './monitoring/metrics.service';
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -15,10 +17,9 @@ async function bootstrap(): Promise<void> {
   const config = app.get(ConfigService<EnvConfig, true>);
 
   app.use(helmet());
+  app.useGlobalInterceptors(new MetricsInterceptor(app.get(MetricsService)));
   app.useGlobalInterceptors(new AuditInterceptor(app.get(AuditLoggerService)));
-  app.useGlobalPipes(
-    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
-  );
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }));
 
   const allowedOrigins = config
     .get('ALLOWED_ORIGINS', { infer: true })

--- a/services/orchestrator/src/monitoring/metrics.interceptor.ts
+++ b/services/orchestrator/src/monitoring/metrics.interceptor.ts
@@ -1,0 +1,38 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Observable, catchError, tap, throwError } from 'rxjs';
+
+import { MetricsService } from './metrics.service';
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(private readonly metrics: MetricsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const request = http.getRequest<Request>();
+    const response = http.getResponse<Response>();
+    const start = process.hrtime.bigint();
+
+    return next.handle().pipe(
+      tap(() => this.observe(request, response.statusCode, start)),
+      catchError((error: Error) => {
+        this.observe(request, response.statusCode >= 400 ? response.statusCode : 500, start);
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  private observe(request: Request, statusCode: number, start: bigint): void {
+    const route = request.route?.path ?? request.url;
+    const durationSeconds = Number(process.hrtime.bigint() - start) / 1_000_000_000;
+    const labels = {
+      method: request.method,
+      route,
+      status: String(statusCode),
+    };
+
+    this.metrics.httpRequests.inc(labels);
+    this.metrics.httpDuration.observe(labels, durationSeconds);
+  }
+}

--- a/services/orchestrator/src/monitoring/metrics.service.ts
+++ b/services/orchestrator/src/monitoring/metrics.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+@Injectable()
+export class MetricsService {
+  readonly registry = new Registry();
+
+  readonly httpRequests = new Counter({
+    name: 'hnh_http_requests_total',
+    help: 'Total HTTP requests handled by the orchestrator',
+    labelNames: ['method', 'route', 'status'] as const,
+    registers: [this.registry],
+  });
+
+  readonly httpDuration = new Histogram({
+    name: 'hnh_http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method', 'route', 'status'] as const,
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+    registers: [this.registry],
+  });
+
+  readonly activeWorkers = new Gauge({
+    name: 'hnh_workers_active',
+    help: 'Currently active worker count',
+    registers: [this.registry],
+  });
+
+  readonly queuedJobs = new Gauge({
+    name: 'hnh_jobs_queued',
+    help: 'Queued job count',
+    registers: [this.registry],
+  });
+
+  readonly openBreakers = new Gauge({
+    name: 'hnh_circuit_breakers_open',
+    help: 'Open circuit breaker count',
+    registers: [this.registry],
+  });
+
+  constructor() {
+    collectDefaultMetrics({ register: this.registry, prefix: 'hnh_' });
+  }
+
+  async render(): Promise<string> {
+    return this.registry.metrics();
+  }
+
+  contentType(): string {
+    return this.registry.contentType;
+  }
+}

--- a/services/orchestrator/src/monitoring/metrics.spec.ts
+++ b/services/orchestrator/src/monitoring/metrics.spec.ts
@@ -1,0 +1,10 @@
+import { MetricsService } from './metrics.service';
+
+describe('orchestrator metrics', () => {
+  it('renders the request counter', async () => {
+    const service = new MetricsService();
+    service.httpRequests.inc({ method: 'GET', route: '/health', status: '200' });
+    const rendered = await service.render();
+    expect(rendered).toContain('hnh_http_requests_total');
+  });
+});

--- a/services/orchestrator/src/monitoring/monitoring.controller.ts
+++ b/services/orchestrator/src/monitoring/monitoring.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+import { MetricsService } from './metrics.service';
+
+@ApiTags('monitoring')
+@Controller('metrics')
+export class MonitoringController {
+  constructor(private readonly metrics: MetricsService) {}
+
+  @Get()
+  @Header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+  @ApiOkResponse({ description: 'Prometheus metrics' })
+  getMetrics(): Promise<string> {
+    return this.metrics.render();
+  }
+}

--- a/services/orchestrator/src/monitoring/monitoring.module.ts
+++ b/services/orchestrator/src/monitoring/monitoring.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { MetricsService } from './metrics.service';
+import { MonitoringController } from './monitoring.controller';
+
+@Module({
+  controllers: [MonitoringController],
+  providers: [MetricsService],
+  exports: [MetricsService]
+})
+export class MonitoringModule {}

--- a/services/orchestrator/src/monitoring/register-monitoring.md
+++ b/services/orchestrator/src/monitoring/register-monitoring.md
@@ -1,0 +1,5 @@
+# Monitoring registration note
+
+Add `MonitoringModule` to `AppModule` imports before enabling the `/metrics` endpoint in production.
+
+The connector blocked the `app.module.ts` update, so this PR carries the module/controller/service scaffolding and documents the required wiring step.

--- a/services/orchestrator/src/monitoring/register-monitoring.ts
+++ b/services/orchestrator/src/monitoring/register-monitoring.ts
@@ -1,0 +1,5 @@
+# Monitoring registration note
+
+Add `MonitoringModule` to `AppModule` imports before enabling the `/metrics` endpoint in production.
+
+The connector blocked the `app.module.ts` update, so this PR carries the module/controller/service scaffolding and documents the required wiring step.


### PR DESCRIPTION
## Summary

Adds the first Prometheus/Grafana observability baseline for the HashNHedge orchestrator.

## Added

- `prom-client` dependency
- Prometheus metrics service
- HTTP request count and duration metrics interceptor
- `GET /metrics` controller scaffold
- monitoring module scaffold
- starter Grafana dashboard JSON
- starter Prometheus alert rules
- metrics and alerting documentation

## Metrics

- `hnh_http_requests_total`
- `hnh_http_request_duration_seconds`
- `hnh_workers_active`
- `hnh_jobs_queued`
- `hnh_circuit_breakers_open`
- default Node/process metrics prefixed with `hnh_`

## Notes

The connector blocked the `AppModule` import update, so this PR includes a follow-up note in `docs/metrics-followup.md` and `src/monitoring/register-monitoring.md`. The remaining wiring step is to import `MonitoringModule` in `AppModule` so `GET /metrics` is live.

Next build step: wire the metrics gauges to database-backed worker/job/breaker counts and add OpenTelemetry tracing.

Progresses #37.