### PR TITLE
Wire metrics gauges and add tracing plan

### DIFF
--- a/services/orchestrator/docs/tracing-plan.md
+++ b/services/orchestrator/docs/tracing-plan.md
@@ -1,0 +1,44 @@
+# Job Lifecycle Tracing Plan
+
+## Goal
+
+Add request and job lifecycle traces so operators can follow a compute job from vendor submission through worker assignment, running state, proof submission, verification, and payout coordination.
+
+## Trace points
+
+- job created
+- job leased
+- worker accepted job
+- job running
+- proof submitted
+- job verified
+- payout requested
+- payout completed
+- job failed
+- job dead-lettered
+- lease recovered
+
+## Required span attributes
+
+- `job.id`
+- `job.type`
+- `job.status`
+- `worker.id`
+- `vendor.id`
+- `lease.id`
+- `retry.count`
+- `circuit_breaker.name`
+- `security.role`
+
+## Recommended implementation
+
+Use OpenTelemetry Node SDK with OTLP export.
+
+Environment variables:
+
+```text
+OTEL_SERVICE_NAME=hashnhedge-orchestrator
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+```
+
+The next implementation PR should add OpenTelemetry dependencies and initialize tracing before NestJS bootstraps.

--- a/services/orchestrator/src/monitoring/metrics.service.ts
+++ b/services/orchestrator/src/monitoring/metrics.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import { JobStatus, WorkerStatus } from '@prisma/client';
 import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+import { CircuitBreakerStore } from '../common/safety/circuit-breaker.store';
+import { PrismaService } from '../database/prisma.service';
 
 @Injectable()
 export class MetricsService {
@@ -32,17 +36,36 @@ export class MetricsService {
     registers: [this.registry],
   });
 
+  readonly runningJobs = new Gauge({
+    name: 'hnh_jobs_running',
+    help: 'Running job count',
+    registers: [this.registry],
+  });
+
   readonly openBreakers = new Gauge({
     name: 'hnh_circuit_breakers_open',
     help: 'Open circuit breaker count',
     registers: [this.registry],
   });
 
-  constructor() {
+  constructor(private readonly prisma: PrismaService, private readonly breakers: CircuitBreakerStore) {
     collectDefaultMetrics({ register: this.registry, prefix: 'hnh_' });
   }
 
+  async updateGauges(): Promise<void> {
+    const activeWorkerCount = await this.prisma.worker.count({ where: { status: WorkerStatus.ACTIVE } });
+    const queuedJobCount = await this.prisma.job.count({ where: { status: JobStatus.QUEUED } });
+    const runningJobCount = await this.prisma.job.count({ where: { status: JobStatus.RUNNING } });
+    const breakerStates = await this.breakers.list();
+
+    this.activeWorkers.set(activeWorkerCount);
+    this.queuedJobs.set(queuedJobCount);
+    this.runningJobs.set(runningJobCount);
+    this.openBreakers.set(breakerStates.filter((breaker) => breaker.open).length);
+  }
+
   async render(): Promise<string> {
+    await this.updateGauges();
     return this.registry.metrics();
   }
 

--- a/services/orchestrator/src/monitoring/monitoring.module.ts
+++ b/services/orchestrator/src/monitoring/monitoring.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 
 import { MetricsService } from './metrics.service';
 import { MonitoringController } from './monitoring.controller';
+import { TracingService } from './tracing.service';
 
 @Module({
   controllers: [MonitoringController],
-  providers: [MetricsService],
-  exports: [MetricsService]
+  providers: [MetricsService, TracingService],
+  exports: [MetricsService, TracingService]
 })
 export class MonitoringModule {}

--- a/services/orchestrator/src/monitoring/tracing.service.ts
+++ b/services/orchestrator/src/monitoring/tracing.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface TraceMetadata {
+  jobId?: string;
+  workerId?: string;
+  requesterId?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+@Injectable()
+export class TracingService {
+  private readonly logger = new Logger('Trace');
+
+  trace(eventName: string, metadata: TraceMetadata = {}): void {
+    this.logger.log(
+      JSON.stringify({
+        eventName,
+        metadata,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Continues the observability buildout after PR #50 by wiring service-level metrics gauges to live orchestrator state and adding the tracing implementation plan.

## Added

- `hnh_jobs_running` gauge
- metrics refresh from persisted worker/job state
- open circuit breaker count refresh from breaker state
- lightweight tracing service scaffold
- job lifecycle tracing plan and OTLP collector notes

## Notes

The connector blocked OpenTelemetry dependency updates and a couple of docs updates, so this PR keeps tracing as a documented implementation plan and focuses the code change on database-backed Prometheus gauges.

Next build step: add vendor marketplace module scaffold and compute job pricing model.

Progresses #37.