### PR TITLE
Add vendor marketplace scaffold

### DIFF
--- a/services/orchestrator/docs/vendor-marketplace.md
+++ b/services/orchestrator/docs/vendor-marketplace.md
@@ -1,0 +1,49 @@
+# Vendor Marketplace
+
+The vendor marketplace module is the entry point for compute buyers.
+
+## Initial scope
+
+- vendor registration scaffold
+- compute price quote endpoint
+- GPU and time pricing model
+- platform fee calculation
+- estimated worker payout calculation
+
+## Endpoints
+
+- `POST /vendors`
+- `GET /vendors`
+- `POST /vendors/price-quote`
+
+Write operations require vendor or admin role and signed requests.
+
+## Pricing model
+
+The first pricing model is intentionally simple:
+
+- subtotal uses hourly GPU rate, GPU count, estimated hours, and priority multiplier
+- platform fee is 15 percent of subtotal
+- total is subtotal plus platform fee
+- worker payout estimate is 85 percent of subtotal
+
+GPU rate examples:
+
+- generic GPU: 1.25 USD per hour
+- RTX 4090: 1.80 USD per hour
+- A100: 4.50 USD per hour
+- H100: 8.50 USD per hour
+
+Priority multipliers:
+
+- economy: 0.8
+- standard: 1.0
+- priority: 1.5
+
+## Next steps
+
+- persist vendors in Prisma
+- connect compute quote to job creation
+- add escrow reserve estimate
+- add SLA and region multipliers
+- add vendor API keys scoped by account

--- a/services/orchestrator/src/vendors/dto/create-vendor.dto.ts
+++ b/services/orchestrator/src/vendors/dto/create-vendor.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsObject, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class CreateVendorDto {
+  @ApiProperty({ example: 'Acme AI Labs' })
+  @IsString()
+  @MinLength(2)
+  name!: string;
+
+  @ApiProperty({ example: 'ops@acme.ai' })
+  @IsEmail()
+  contactEmail!: string;
+
+  @ApiPropertyOptional({ example: 'GCKbEgD4VSLtkwt57At7pWscaxaQ2gBZtTQE2hqr3Yrc' })
+  @IsOptional()
+  @IsString()
+  walletAddress?: string;
+
+  @ApiPropertyOptional({ example: { tier: 'startup', billing: 'prepaid' } })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/services/orchestrator/src/vendors/dto/price-compute.dto.ts
+++ b/services/orchestrator/src/vendors/dto/price-compute.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsInt, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+
+export class PriceComputeDto {
+  @ApiProperty({ example: 'ai-inference' })
+  @IsString()
+  jobType!: string;
+
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  @Min(1)
+  gpuCount!: number;
+
+  @ApiProperty({ example: 30 })
+  @IsNumber()
+  @Min(0.01)
+  estimatedMinutes!: number;
+
+  @ApiPropertyOptional({ example: 'NVIDIA RTX 4090' })
+  @IsOptional()
+  @IsString()
+  gpuModel?: string;
+
+  @ApiPropertyOptional({ example: 'standard', enum: ['economy', 'standard', 'priority'] })
+  @IsOptional()
+  @IsIn(['economy', 'standard', 'priority'])
+  priority?: 'economy' | 'standard' | 'priority';
+}

--- a/services/orchestrator/src/vendors/vendor-pricing.service.spec.ts
+++ b/services/orchestrator/src/vendors/vendor-pricing.service.spec.ts
@@ -1,0 +1,19 @@
+import { VendorPricingService } from './vendor-pricing.service';
+
+describe('VendorPricingService', () => {
+  it('quotes compute jobs with platform fee and worker payout', () => {
+    const service = new VendorPricingService();
+    const quote = service.quote({
+      jobType: 'ai-inference',
+      gpuCount: 2,
+      estimatedMinutes: 60,
+      gpuModel: 'NVIDIA RTX 4090',
+      priority: 'standard',
+    });
+
+    expect(quote.subtotalUsd).toBe(3.6);
+    expect(quote.platformFeeUsd).toBe(0.54);
+    expect(quote.totalUsd).toBe(4.14);
+    expect(quote.estimatedWorkerPayoutUsd).toBe(3.06);
+  });
+});

--- a/services/orchestrator/src/vendors/vendor-pricing.service.ts
+++ b/services/orchestrator/src/vendors/vendor-pricing.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+
+import { PriceComputeDto } from './dto/price-compute.dto';
+
+export interface ComputePriceQuote {
+  currency: 'USD';
+  subtotalUsd: number;
+  platformFeeUsd: number;
+  totalUsd: number;
+  estimatedWorkerPayoutUsd: number;
+  inputs: PriceComputeDto;
+}
+
+@Injectable()
+export class VendorPricingService {
+  quote(dto: PriceComputeDto): ComputePriceQuote {
+    const hourlyRate = this.hourlyRate(dto.gpuModel);
+    const priorityMultiplier = this.priorityMultiplier(dto.priority ?? 'standard');
+    const hours = dto.estimatedMinutes / 60;
+    const subtotalUsd = roundMoney(hourlyRate * dto.gpuCount * hours * priorityMultiplier);
+    const platformFeeUsd = roundMoney(subtotalUsd * 0.15);
+    const totalUsd = roundMoney(subtotalUsd + platformFeeUsd);
+    const estimatedWorkerPayoutUsd = roundMoney(subtotalUsd * 0.85);
+
+    return {
+      currency: 'USD',
+      subtotalUsd,
+      platformFeeUsd,
+      totalUsd,
+      estimatedWorkerPayoutUsd,
+      inputs: dto,
+    };
+  }
+
+  private hourlyRate(gpuModel?: string): number {
+    const normalized = gpuModel?.toLowerCase() ?? '';
+
+    if (normalized.includes('4090')) return 1.8;
+    if (normalized.includes('a100')) return 4.5;
+    if (normalized.includes('h100')) return 8.5;
+    return 1.25;
+  }
+
+  private priorityMultiplier(priority: 'economy' | 'standard' | 'priority'): number {
+    if (priority === 'economy') return 0.8;
+    if (priority === 'priority') return 1.5;
+    return 1;
+  }
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/services/orchestrator/src/vendors/vendors.controller.ts
+++ b/services/orchestrator/src/vendors/vendors.controller.ts
@@ -1,0 +1,46 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+
+import { AuthGuard } from '../auth/auth.guard';
+import { RequestSigningGuard } from '../auth/request-signing.guard';
+import { Role } from '../auth/roles';
+import { Roles } from '../auth/roles.decorator';
+import { SignedRoute } from '../auth/signed.decorator';
+import { CreateVendorDto } from './dto/create-vendor.dto';
+import { PriceComputeDto } from './dto/price-compute.dto';
+import { ComputePriceQuote, VendorPricingService } from './vendor-pricing.service';
+import { VendorRecord, VendorsService } from './vendors.service';
+
+@ApiTags('vendors')
+@ApiSecurity('x-hnh-api-key')
+@Controller('vendors')
+@UseGuards(AuthGuard, RequestSigningGuard)
+export class VendorsController {
+  constructor(
+    private readonly vendors: VendorsService,
+    private readonly pricing: VendorPricingService,
+  ) {}
+
+  @Post()
+  @SignedRoute()
+  @Roles(Role.Vendor, Role.Admin)
+  @ApiCreatedResponse({ description: 'Vendor registered' })
+  createVendor(@Body() dto: CreateVendorDto): VendorRecord {
+    return this.vendors.createVendor(dto);
+  }
+
+  @Get()
+  @Roles(Role.Admin)
+  @ApiOkResponse({ description: 'Registered vendors' })
+  listVendors(): VendorRecord[] {
+    return this.vendors.listVendors();
+  }
+
+  @Post('price-quote')
+  @SignedRoute()
+  @Roles(Role.Vendor, Role.Admin)
+  @ApiOkResponse({ description: 'Compute job price quote' })
+  quote(@Body() dto: PriceComputeDto): ComputePriceQuote {
+    return this.pricing.quote(dto);
+  }
+}

--- a/services/orchestrator/src/vendors/vendors.module.ts
+++ b/services/orchestrator/src/vendors/vendors.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { VendorPricingService } from './vendor-pricing.service';
+import { VendorsController } from './vendors.controller';
+import { VendorsService } from './vendors.service';
+
+@Module({
+  controllers: [VendorsController],
+  providers: [VendorsService, VendorPricingService],
+  exports: [VendorsService, VendorPricingService]
+})
+export class VendorsModule {}

--- a/services/orchestrator/src/vendors/vendors.service.ts
+++ b/services/orchestrator/src/vendors/vendors.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+
+import { CreateVendorDto } from './dto/create-vendor.dto';
+
+export interface VendorRecord {
+  id: string;
+  name: string;
+  contactEmail: string;
+  walletAddress?: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+@Injectable()
+export class VendorsService {
+  private readonly vendors = new Map<string, VendorRecord>();
+  private sequence = 0;
+
+  createVendor(dto: CreateVendorDto): VendorRecord {
+    const id = this.nextId();
+    const vendor: VendorRecord = {
+      id,
+      name: dto.name,
+      contactEmail: dto.contactEmail,
+      walletAddress: dto.walletAddress,
+      metadata: dto.metadata ?? {},
+      createdAt: new Date().toISOString(),
+    };
+    this.vendors.set(id, vendor);
+    return vendor;
+  }
+
+  listVendors(): VendorRecord[] {
+    return Array.from(this.vendors.values());
+  }
+
+  private nextId(): string {
+    this.sequence += 1;
+    return 'vendor_' + Date.now() + '_' + this.sequence;
+  }
+}


### PR DESCRIPTION
## Summary

Starts the vendor marketplace workstream.

## Added

- vendor creation DTO
- compute pricing DTO
- vendor service scaffold
- vendor controller
- vendors module
- pricing service
- pricing unit test
- vendor marketplace docs

## Notes

This first pass uses in-memory vendor storage. Next step: persist vendors in Prisma and connect quotes to job creation.